### PR TITLE
message queue counter and control UI Fixes #652

### DIFF
--- a/blocks.js
+++ b/blocks.js
@@ -4813,7 +4813,6 @@ HatBlockMorph.prototype.init = function () {
     // init readout
     this.msgCount = 10;
     this.readColor = new Color(200, 20, 20);
-    this.updateReadout();
 };
 
 HatBlockMorph.prototype.readout = function () {
@@ -4821,9 +4820,18 @@ HatBlockMorph.prototype.readout = function () {
     return this.children.find(morph => morph instanceof SpeechBubbleMorph);
 };
 
+// finds and returns the msg queue for this hatblock
+HatBlockMorph.prototype._msgQueue = function () {
+    let queues = world.children[0].sockets.processes;
+    let scriptQ = queues.find((p, i) => p.length && p[0].block === this);
+    return scriptQ;
+}
+
 HatBlockMorph.prototype.updateReadout = function () {
     // TODO get the message type for this hatblock and count
     console.log('updating readout', this);
+    let msgQ = this._msgQueue();
+    this.msgCount =  msgQ ? msgQ.length : 0;
     var readout = this.readout();
     if (this.msgCount < 1) {
         if (readout) {

--- a/blocks.js
+++ b/blocks.js
@@ -4809,6 +4809,53 @@ function HatBlockMorph() {
 HatBlockMorph.prototype.init = function () {
     HatBlockMorph.uber.init.call(this, true); // silently
     this.setExtent(new Point(300, 150));
+
+    // init readout
+    this.msgCount = 10;
+    this.readColor = new Color(200, 20, 20);
+    this.updateReadout();
+};
+
+HatBlockMorph.prototype.readout = function () {
+    // TODO ES5 4fd6190c
+    return this.children.find(morph => morph instanceof SpeechBubbleMorph);
+};
+
+HatBlockMorph.prototype.updateReadout = function () {
+    // TODO get the message type for this hatblock and count
+    console.log('updating readout', this);
+    var readout = this.readout();
+    if (this.msgCount < 1) {
+        if (readout) {
+            readout.destroy();
+        }
+        return;
+    }
+    if (readout) {
+        readout.contents = this.msgCount.toString();
+        readout.fullChanged();
+        readout.drawNew();
+        readout.fullChanged();
+    } else {
+        readout = new SpeechBubbleMorph(
+            this.msgCount.toString(),
+            this.readColor, // color,
+            null, // edge,
+            null, // border,
+            this.readColor.darker(), // borderColor,
+            null, // padding,
+            1 // isThought - don't draw a hook
+        );
+        this.add(readout);
+    }
+
+    // compute and set the bubble position
+    const padding = 5;
+    var bubblePos = this.position() // hatblock pos
+        .add(new Point(this.width(), 0)) // all the way to the right
+        .add(new Point(padding, -2*padding)); // add a padding (same for x & y)
+    readout.setPosition(bubblePos);
+
 };
 
 // HatBlockMorph enumerating:

--- a/blocks.js
+++ b/blocks.js
@@ -4847,7 +4847,7 @@ HatBlockMorph.prototype.updateReadout = function () {
     var myself = this,
         world = this.world(),
         readColor = new Color(22, 137, 20);
-
+    if (!world) return;
     var msgQ = this._msgQueue();
     this.msgCount =  msgQ ? msgQ.length : 0;
     var readout = this.readout();

--- a/blocks.js
+++ b/blocks.js
@@ -4846,7 +4846,7 @@ HatBlockMorph.prototype.updateReadout = function () {
     // forked from snap/dd4fd6190c
     var myself = this,
         world = this.world(),
-        readColor = new Color(22, 137, 20);
+        readColor = new Color(242, 119, 68);
     if (!world) return;
     var msgQ = this._msgQueue();
     this.msgCount =  msgQ ? msgQ.length : 0;

--- a/blocks.js
+++ b/blocks.js
@@ -4811,7 +4811,7 @@ HatBlockMorph.prototype.init = function () {
     this.setExtent(new Point(300, 150));
 
     // init readout
-    this.msgCount = 10;
+    this.msgCount = 0;
     this.readColor = new Color(200, 20, 20);
 };
 
@@ -4827,9 +4827,23 @@ HatBlockMorph.prototype._msgQueue = function () {
     return scriptQ;
 }
 
+// clears the msg que for this  hatblock
+HatBlockMorph.prototype.clearMessages = function () {
+    let queues = world.children[0].sockets.processes;
+    let curQueue = this._msgQueue();
+    // delete it from the main queue
+    for (let i = 0; i < queues.length; i++) {
+        if (queues[i] === curQueue) {
+            queues.splice(i, 1);
+            this.updateReadout();
+            return;
+        }
+    }
+}
+
 HatBlockMorph.prototype.updateReadout = function () {
     // TODO get the message type for this hatblock and count
-    console.log('updating readout', this);
+    var myself = this;
     let msgQ = this._msgQueue();
     this.msgCount =  msgQ ? msgQ.length : 0;
     var readout = this.readout();
@@ -4854,6 +4868,14 @@ HatBlockMorph.prototype.updateReadout = function () {
             null, // padding,
             1 // isThought - don't draw a hook
         );
+        readout.mouseClickLeft = pos => {
+            let dialog = new DialogBoxMorph();
+            dialog.askYesNo('Clear Message Queue', 'Do you want to clear the message queue for this block?', world);
+            dialog.ok = function() {
+                myself.clearMessages();
+                this.destroy();
+            };
+        };
         this.add(readout);
     }
 

--- a/blocks.js
+++ b/blocks.js
@@ -697,7 +697,7 @@ SyntaxElementMorph.prototype.refactorVarInStack = function (
         this.setSpec(newName);
         this.fullChanged();
         this.fixLabelColor();
-    } 
+    }
 
     if (this.choices === 'getVarNamesDict'
             && this.contents().text === oldName) {
@@ -3244,7 +3244,7 @@ BlockMorph.prototype.refactorThisVar = function (justTheTemplate) {
 
     function renameVarTo (newName) {
         var definer;
-        
+
         if (this.parent instanceof SyntaxElementMorph) {
             // script var
             if (justTheTemplate) {
@@ -3303,7 +3303,7 @@ BlockMorph.prototype.refactorThisVar = function (justTheTemplate) {
                     detect(
                         stage.children,
                         function (any) {
-                            return any instanceof SpriteMorph && 
+                            return any instanceof SpriteMorph &&
                                 any.hasSpriteVariable(newName);
                         })
                     ) {
@@ -3363,7 +3363,7 @@ BlockMorph.prototype.refactorThisVar = function (justTheTemplate) {
 
     function varExistsError (where) {
         ide.inform(
-            'Variable exists', 
+            'Variable exists',
             'A variable with this name already exists ' +
                 (where || 'in this context') + '.'
             );
@@ -11137,7 +11137,7 @@ SymbolMorph.prototype.drawSymbolMagnifyingGlass = function (canvas, color) {
         y + r,
         w
     );
-    
+
     gradient.addColorStop(0, color.inverted().lighter(50).toString());
     gradient.addColorStop(1, color.inverted().darker(25).toString());
     ctx.fillStyle = gradient;
@@ -11147,7 +11147,7 @@ SymbolMorph.prototype.drawSymbolMagnifyingGlass = function (canvas, color) {
     ctx.lineWidth = l / 2;
     ctx.arc(x, y, r, radians(0), radians(360), false);
     ctx.stroke();
-    
+
     ctx.lineWidth = l;
     ctx.beginPath();
     ctx.moveTo(l / 2, h - l / 2);

--- a/blocks.js
+++ b/blocks.js
@@ -4809,42 +4809,46 @@ function HatBlockMorph() {
 HatBlockMorph.prototype.init = function () {
     HatBlockMorph.uber.init.call(this, true); // silently
     this.setExtent(new Point(300, 150));
-
-    // init readout
-    this.msgCount = 0;
-    this.readColor = new Color(200, 20, 20);
 };
 
+// finds the readout child morph
 HatBlockMorph.prototype.readout = function () {
-    // TODO ES5 4fd6190c
-    return this.children.find(morph => morph instanceof SpeechBubbleMorph);
+    for (var i=0; i<this.children.length; i++) {
+        if (this.children[i] instanceof SpeechBubbleMorph) return this.children[i];
+    }
 };
 
 // finds and returns the msg queue for this hatblock
 HatBlockMorph.prototype._msgQueue = function () {
-    let queues = world.children[0].sockets.processes;
-    let scriptQ = queues.find((p, i) => p.length && p[0].block === this);
-    return scriptQ;
-}
+    var queues = this.world().children[0].sockets.processes;
+    for (var i=0; i<queues.length; i++) {
+        var procs = queues[i];
+        if (procs.length && procs[0].block === this) return procs;
+    }
+};
 
 // clears the msg que for this  hatblock
 HatBlockMorph.prototype.clearMessages = function () {
-    let queues = world.children[0].sockets.processes;
-    let curQueue = this._msgQueue();
+    var queues = this.world().children[0].sockets.processes;
+    var curQueue = this._msgQueue();
     // delete it from the main queue
-    for (let i = 0; i < queues.length; i++) {
+    for (var i = 0; i < queues.length; i++) {
         if (queues[i] === curQueue) {
             queues.splice(i, 1);
             this.updateReadout();
             return;
         }
     }
-}
+};
 
+// creates, updates and destroys the readout as necessary
 HatBlockMorph.prototype.updateReadout = function () {
-    // TODO get the message type for this hatblock and count
-    var myself = this;
-    let msgQ = this._msgQueue();
+    // forked from snap/dd4fd6190c
+    var myself = this,
+        world = this.world(),
+        readColor = new Color(22, 137, 20);
+
+    var msgQ = this._msgQueue();
     this.msgCount =  msgQ ? msgQ.length : 0;
     var readout = this.readout();
     if (this.msgCount < 1) {
@@ -4853,23 +4857,23 @@ HatBlockMorph.prototype.updateReadout = function () {
         }
         return;
     }
-    if (readout) {
+    if (readout) { // just update the value
         readout.contents = this.msgCount.toString();
         readout.fullChanged();
         readout.drawNew();
         readout.fullChanged();
-    } else {
+    } else { // create the readout
         readout = new SpeechBubbleMorph(
             this.msgCount.toString(),
-            this.readColor, // color,
+            readColor, // color,
             null, // edge,
             null, // border,
-            this.readColor.darker(), // borderColor,
+            readColor.darker(), // borderColor,
             null, // padding,
             1 // isThought - don't draw a hook
         );
-        readout.mouseClickLeft = pos => {
-            let dialog = new DialogBoxMorph();
+        readout.mouseClickLeft = function() {
+            var dialog = new DialogBoxMorph();
             dialog.askYesNo('Clear Message Queue', 'Do you want to clear the message queue for this block?', world);
             dialog.ok = function() {
                 myself.clearMessages();

--- a/test/messages.spec.js
+++ b/test/messages.spec.js
@@ -37,5 +37,34 @@ describe('messages', function() {
                 expect(!!btn).toBe(true);
             });
         });
+
+        it.only('should show queue message count', function() {
+            var hatBlock, // hatblock
+                doWait;
+            driver.addBlock('receiveSocketMessage')
+                .then(_block => {
+                    hatBlock = _block;
+                    const msgField = hatBlock.inputs()[0];
+                    // set the msg type to message
+                    return SnapActions.setField(msgField, 'message');
+                })
+                .then(() => {
+                    return driver.addBlock('doWait');
+                })
+                .then(_doWait => {
+                    doWait = _doWait;
+                    return SnapActions.setField(doWait.inputs()[0], '0.5');
+                })
+                .then(() => {
+                    let Point = driver.globals().Point;
+                    let dropPosition = hatBlock.bottomAttachPoint()
+                        .add(new Point(doWait.width()/2, doWait.height()/2))
+                        .subtract(doWait.topAttachPoint().subtract(doWait.topLeft()))
+                        .subtract(new Point(0, 3));
+                    driver.dragAndDrop(doWait, dropPosition);
+                })
+                .catch(console.error);
+
+        });
     });
 });

--- a/test/messages.spec.js
+++ b/test/messages.spec.js
@@ -38,7 +38,7 @@ describe('messages', function() {
             });
         });
 
-        it.only('should show queue message count', function() {
+        it('should show queue message count', function() {
             var hatBlock, // hatblock
                 doWait;
             driver.addBlock('receiveSocketMessage')
@@ -62,8 +62,7 @@ describe('messages', function() {
                         .subtract(doWait.topAttachPoint().subtract(doWait.topLeft()))
                         .subtract(new Point(0, 3));
                     driver.dragAndDrop(doWait, dropPosition);
-                })
-                .catch(console.error);
+                });
 
         });
     });

--- a/test/messages.spec.js
+++ b/test/messages.spec.js
@@ -38,32 +38,41 @@ describe('messages', function() {
             });
         });
 
-        it('should show queue message count', function() {
-            var hatBlock, // hatblock
-                doWait;
-            driver.addBlock('receiveSocketMessage')
-                .then(_block => {
-                    hatBlock = _block;
-                    const msgField = hatBlock.inputs()[0];
-                    // set the msg type to message
-                    return SnapActions.setField(msgField, 'message');
-                })
-                .then(() => {
-                    return driver.addBlock('doWait');
-                })
-                .then(_doWait => {
-                    doWait = _doWait;
-                    return SnapActions.setField(doWait.inputs()[0], '0.5');
-                })
-                .then(() => {
-                    let Point = driver.globals().Point;
-                    let dropPosition = hatBlock.bottomAttachPoint()
-                        .add(new Point(doWait.width()/2, doWait.height()/2))
-                        .subtract(doWait.topAttachPoint().subtract(doWait.topLeft()))
-                        .subtract(new Point(0, 3));
-                    driver.dragAndDrop(doWait, dropPosition);
-                });
+        it('should show queue message count', async function() {
+            const MIN_DELAY = 50;
+            const hatBlock = await driver.addBlock('receiveSocketMessage');
+            const msgField = hatBlock.inputs()[0];
+            // set the msg type to message
+            await SnapActions.setField(msgField, 'message');
+            const doWait = await driver.addBlock('doWait');
+            await SnapActions.setField(doWait.inputs()[0], '0.5');
+            // attach doWait to hatblock
+            let Point = driver.globals().Point;
+            let dropPosition = hatBlock.bottomAttachPoint()
+                .add(new Point(doWait.width()/2, doWait.height()/2))
+                .subtract(doWait.topAttachPoint().subtract(doWait.topLeft()))
+                .subtract(new Point(0, 3));
+            driver.dragAndDrop(doWait, dropPosition); // attach
+            await driver.sleep(MIN_DELAY);
+            driver.dragAndDrop(hatBlock, dropPosition.add(new Point(200, 200))); // move away
+            await driver.sleep(MIN_DELAY);
 
+            // create the message sender
+            const doSocketBlock = await driver.addBlock('doSocketMessage');
+            // setup the fields
+            await SnapActions.setField(doSocketBlock.inputs()[0], 'message');
+            await SnapActions.setField(doSocketBlock.inputs()[1], 'some message');
+            await SnapActions.setField(doSocketBlock.inputs()[2], 'everyone in room');
+
+            // send 10 messages
+            for (let i=0; i<10; i++) {
+                driver.click(doSocketBlock);
+                await driver.sleep(MIN_DELAY);
+            }
+
+            hatBlock.updateReadout();
+            console.assert(hatBlock._msgQueue().length > 0);
+            console.assert(hatBlock._msgQueue().length < 9);
         });
     });
 });

--- a/websockets.js
+++ b/websockets.js
@@ -527,6 +527,7 @@ WebSocketManager.prototype.startProcesses = function () {
         activeBlock = !!stage.threads.findProcess(block);
         if (!activeBlock) {  // Check if the process can be added
             process = this.processes[i].shift();
+            process.block.updateReadout();
             stage.threads.startProcess(
                 process.block,
                 process.isThreadSafe,


### PR DESCRIPTION
adds a number next to message listener hatblocks showing the messages in the queue with support for clearing the queue. 
This should allow us to remove the need for throttling sending of the messages on the server and might eliminate the need for `stop` rpcs in some of the services.