### PR TITLE
Fix #346

### DIFF
--- a/actions.js
+++ b/actions.js
@@ -572,9 +572,12 @@ ActionManager.prototype.newId = function() {
 };
 
 ActionManager.prototype.getId = function (block, index) {
-    var id = '';
+    var id = '',
+        isParentCodeElement;
+
     while (!block.id) {
-        if (block.parent === null || typeof block.parent.inputs !== 'function') {  // template block
+        isParentCodeElement = block.parent instanceof SyntaxElementMorph;
+        if (!isParentCodeElement) {
             return null;
         }
         id = block.parent.inputs().indexOf(block) + '/' + id;

--- a/actions.js
+++ b/actions.js
@@ -574,7 +574,7 @@ ActionManager.prototype.newId = function() {
 ActionManager.prototype.getId = function (block, index) {
     var id = '';
     while (!block.id) {
-        if (block.parent === null) {  // template block
+        if (block.parent === null || typeof block.parent.inputs !== 'function') {  // template block
             return null;
         }
         id = block.parent.inputs().indexOf(block) + '/' + id;


### PR DESCRIPTION
This prevents the error causing the "shadow of death". Now the ring can be dragged out just like the rings in the operators category.