### PR TITLE
Driver dragAndDrop now grabs from top left by default Fix #692

### DIFF
--- a/test/snap-driver.js
+++ b/test/snap-driver.js
@@ -171,7 +171,9 @@ SnapDriver.prototype.dragAndDrop = function(srcMorph, position, start = null) {
     
     // Drag from the upper left corner if not told otherwise
     if(start == null)
+    {
         start = srcMorph.topLeft().add(new Point(2,srcMorph.height() / 2));
+    }
     
     // If Morph is not grabbed at center, final position will no longer be correct
     let offset = start.subtract(srcMorph.center());

--- a/test/snap-driver.js
+++ b/test/snap-driver.js
@@ -172,16 +172,16 @@ SnapDriver.prototype.dragAndDrop = function(srcMorph, position, start = null) {
     // Drag from the upper left corner if not told otherwise
     if(start == null)
     {
-        start = srcMorph.topLeft().add(new Point(2,srcMorph.height() / 2));
+        start = srcMorph.topLeft().add(new Point(2, srcMorph.height() / 2));
     }
     
-    // If Morph is not grabbed at center, final position will no longer be correct
+    // If the Morph is not grabbed at center, final position will no longer be correct
     let offset = start.subtract(srcMorph.center());
     
     this.mouseDown(start);
     this.world().hand.processMouseMove({
         pageY: start.y,
-        pageX: start.x + MorphicPreferences.grabThreshold+1
+        pageX: start.x + MorphicPreferences.grabThreshold + 1
     });
     this.mouseUp(position.add(offset));
 };

--- a/test/snap-driver.js
+++ b/test/snap-driver.js
@@ -160,16 +160,28 @@ SnapDriver.prototype.mouseUp = function(position) {
     hand.processMouseUp();
 };
 
-SnapDriver.prototype.dragAndDrop = function(srcMorph, position) {
-    const start = srcMorph.center();
+/**
+ * Simulates mouse inputs to pick up a Morph and place it somewhere else.
+ * @param {Morph} srcMorph Morph to drag and drop
+ * @param {Point} position Position to drag center of srcMorph to 
+ * @param {Point=} start Position to initiate drag at, if not speficied top left corner of srcMorph is used
+ */
+SnapDriver.prototype.dragAndDrop = function(srcMorph, position, start = null) {
     const {MorphicPreferences} = this.globals();
-
+    
+    // Drag from the upper left corner if not told otherwise
+    if(start == null)
+        start = srcMorph.topLeft();
+    
+    // If Morph is not grabbed at center, final position will no longer be correct
+    let offset = start.subtract(srcMorph.center());
+    
     this.mouseDown(start);
     this.world().hand.processMouseMove({
         pageY: start.y,
         pageX: start.x + MorphicPreferences.grabThreshold+1
     });
-    this.mouseUp(position);
+    this.mouseUp(position.add(offset));
 };
 
 SnapDriver.prototype.sleep = function(duration) {

--- a/test/snap-driver.js
+++ b/test/snap-driver.js
@@ -164,7 +164,7 @@ SnapDriver.prototype.mouseUp = function(position) {
  * Simulates mouse inputs to pick up a Morph and place it somewhere else.
  * @param {Morph} srcMorph Morph to drag and drop
  * @param {Point} position Position to drag center of srcMorph to 
- * @param {Point=} start Position to initiate drag at, if not speficied top left corner of srcMorph is used
+ * @param {Point=} start Position to initiate drag at, if not speficied middle of left side of srcMorph is used
  */
 SnapDriver.prototype.dragAndDrop = function(srcMorph, position, start = null) {
     const {MorphicPreferences, Point} = this.globals();

--- a/test/snap-driver.js
+++ b/test/snap-driver.js
@@ -167,11 +167,11 @@ SnapDriver.prototype.mouseUp = function(position) {
  * @param {Point=} start Position to initiate drag at, if not speficied top left corner of srcMorph is used
  */
 SnapDriver.prototype.dragAndDrop = function(srcMorph, position, start = null) {
-    const {MorphicPreferences} = this.globals();
+    const {MorphicPreferences, Point} = this.globals();
     
     // Drag from the upper left corner if not told otherwise
     if(start == null)
-        start = srcMorph.topLeft();
+        start = srcMorph.topLeft().add(new Point(2,srcMorph.height() / 2));
     
     // If Morph is not grabbed at center, final position will no longer be correct
     let offset = start.subtract(srcMorph.center());


### PR DESCRIPTION
Fixes #692, now drags are from top left, test that was failing before now passes.