### PR TITLE
Added support for editing custom blocks with the keyboard. Fixes #703

### DIFF
--- a/gui.js
+++ b/gui.js
@@ -697,6 +697,13 @@ IDE_Morph.prototype.onUnsetActive = function () {
     }
 };
 
+IDE_Morph.prototype.getActiveScripts = function () {
+    if (this.activeEditor instanceof BlockEditorMorph) {
+        return this.activeEditor.body.contents;
+    }
+    return this.currentSprite.scripts;
+};
+
 IDE_Morph.prototype.getActiveEntity = function () {
     // Return the entity which is the subject of the focus. If a block editor
     // is open, return the definition which is being edited, else return the

--- a/objects.js
+++ b/objects.js
@@ -6080,8 +6080,9 @@ StageMorph.prototype.editScripts = function () {
     var ide = this.parentThatIsA(IDE_Morph),
         scripts,
         sorted;
+
     if (ide.isAppMode || !ScriptsMorph.prototype.enableKeyboard) {return; }
-    scripts = this.parentThatIsA(IDE_Morph).currentSprite.scripts;
+    scripts = ide.getActiveScripts();
     scripts.edit(scripts.position());
     sorted = scripts.focus.sortedScripts();
     if (sorted.length) {


### PR DESCRIPTION
This simply adds support for detecting the correct scripts when starting keyboard editing mode. It does not stop keyboard editing until the user actually presses escape and the script cursor will keep the keyboard focus until then, too.