### PR TITLE
Removed unnecessary clearing role. Fixes #728

### DIFF
--- a/netsblox.js
+++ b/netsblox.js
@@ -605,9 +605,6 @@ NetsBloxMorph.prototype.openRoomString = function (str) {
     role = room.children[0].attributes.name;
 
     var msg = this.showMessage('Opening project...');
-    // Create a room with the new name
-    this.newRole(role);
-
     var myself = this,
         name = room.attributes.name;
 


### PR DESCRIPTION
The unnecessary clearing of the role was resulting in the project getting out-of-sync with the version on the server. As a result, it was not able to determine the number of occupants at the role.