### PR TITLE
"<" serialization in event arguments fixes #732

### DIFF
--- a/store.js
+++ b/store.js
@@ -208,8 +208,8 @@ XML_Serializer.prototype.getArgumentXML = function (tag, item) {
             }
         }).join('');
 
-    } else if (typeof item === 'string' && item[0] === '<') {
-        xml = '<![CDATA[' + item.replace(/]]>/g, '&ncdata;]>') + ']]>';
+    } else if (typeof item === 'string' && item.indexOf('<') > -1) {
+        xml = item.replace(/</g, '&lt;');
     }
 
     return [


### PR DESCRIPTION
snap's `xml.js` replaces this character with `&lt;`