### PR TITLE
Allow setting variables through `postMessage`

### DIFF
--- a/index.dev.html
+++ b/index.dev.html
@@ -56,6 +56,7 @@
 				world.doOneCycle();
 			}
 		</script>
+    <script type="text/javascript" src="on-message.js"></script>
     </head>
     <body style="margin: 0;">
         <canvas id="world" tabindex="1" style="position: absolute;" ></canvas>

--- a/index.dot
+++ b/index.dot
@@ -78,6 +78,7 @@
 				world.doOneCycle();
 			}
 		</script>
+    <script type="text/javascript" src="on-message.js"></script>
     </head>
     <body style="margin: 0;">
         <canvas id="world" tabindex="1" style="position: absolute;" ></canvas>

--- a/on-message.js
+++ b/on-message.js
@@ -1,8 +1,13 @@
+window.externalVariables = {}
+
 var receiveMessage = function(event) {
   switch (event.data.type) {
     case "import":
       var nbm = world.children.find(function(x) { return x instanceof NetsBloxMorph; });
       nbm.droppedText(event.data.blocks, event.data.name);
+      break;
+    case "set-variable":
+      externalVariables[event.data.key] = event.data.value;
       break;
   }
 }

--- a/on-message.js
+++ b/on-message.js
@@ -1,0 +1,10 @@
+var receiveMessage = function(event) {
+  switch (event.data.type) {
+    case "import":
+      var nbm = world.children.find(function(x) { return x instanceof NetsBloxMorph; });
+      nbm.droppedText(event.data.blocks, event.data.name);
+      break;
+  }
+}
+
+window.addEventListener("message", receiveMessage, false);


### PR DESCRIPTION
This is relevant to embedding NetsBlox inside of an `iframe`, in that it allows for passing in arbitrary data that can be accessed from within custom JavaScript blocks.

For me personally, my project to embed NetsBlox into a "web gallery" uses this functionality for passing in data from the URL hash.  Theoretically, that should be possible without using `postMessage`, but Chrome and Chromium currently do no update an `iframe`'s `location.hash` in the intuitive way.  For more some discussion on that, see #731.