### PR TITLE
per block message send rate limit. Fixes #662

### DIFF
--- a/threads-ext.js
+++ b/threads-ext.js
@@ -77,7 +77,7 @@ NetsProcess.prototype.doSocketMessage = function (msgInfo) {
     var id = 'asyncFn-sendMsg';
     if (!this[id]) {
         this[id] = {};
-        this[id].startTime = new Date().getTime();
+        this[id].endTime = new Date().getTime() + delay;
         ide.sockets.sendMessage({
             type: 'message',
             dstId: targetRole,
@@ -88,8 +88,8 @@ NetsProcess.prototype.doSocketMessage = function (msgInfo) {
         this[id].onerror = function(event) {
             this[id].error = event;
         };
-    } else if ((new Date().getTime() - this[id].startTime) > delay) {
-        // Clear request
+    } else if (new Date().getTime() > this[id].endTime) {
+        // delay is passed
         this[id] = null;
         return;
     }

--- a/threads-ext.js
+++ b/threads-ext.js
@@ -71,13 +71,30 @@ NetsProcess.prototype.doSocketMessage = function (msgInfo) {
         contents[fieldNames[i]] = fieldValues[i] || '';
     }
 
-    ide.sockets.sendMessage({
-        type: 'message',
-        dstId: targetRole,
-        srcId: srcId,
-        msgType: name,
-        content: contents
-    });
+    var OUTPUT_RATE = 30; // per second (approx)
+    var delay = 1000 / OUTPUT_RATE;
+
+    var id = 'asyncFn-sendMsg';
+    if (!this[id]) {
+        this[id] = {};
+        this[id].startTime = new Date().getTime();
+        ide.sockets.sendMessage({
+            type: 'message',
+            dstId: targetRole,
+            srcId: srcId,
+            msgType: name,
+            content: contents
+        });
+        this[id].onerror = function(event) {
+            this[id].error = event;
+        };
+    } else if ((new Date().getTime() - this[id].startTime) > delay) {
+        // Clear request
+        this[id] = null;
+        return;
+    }
+    this.pushContext('doYield');
+    this.pushContext();
 };
 
 //request block


### PR DESCRIPTION
- goes with https://github.com/NetsBlox/NetsBlox/pull/2286
- this sort of rate limiting is only on the client side and thus could be avoided by the user therefore only protecting against unintentional bursts of messages