### PR TITLE
show the open project name in page title fixes #785

### DIFF
--- a/netsblox.js
+++ b/netsblox.js
@@ -255,6 +255,9 @@ NetsBloxMorph.prototype.createControlBar = function () {
             return;
         }
 
+        // update the document title
+        document.title = headerName + suffix + ' - ' + myself.serializer.appName;
+
         this.label = new StringMorph(
             headerName + suffix,
             14,


### PR DESCRIPTION
other ways of showing it could be to:
- append it 
- have it scroll
- NetsBlox [projectname rol]

since the page favicon will indicate that it's from NetsBlox I'll prepend the project name instead of appending it