### PR TITLE
cached sync xhr requests for rpc method signatures

### DIFF
--- a/blocks-ext.js
+++ b/blocks-ext.js
@@ -322,7 +322,7 @@ RPCInputSlotMorph.prototype.methodSignature = function () {
     if (rpc) {
         // stores information on a specific service's rpcs
         try {
-            this.fieldsFor = JSON.parse(this.getURL('/rpc/' + rpc)).rpcs;
+            this.fieldsFor = JSON.parse(getUrlSyncCached('/rpc/' + rpc)).rpcs;
         } catch (e) {
             throw new Error('Service "' + rpc + '" is not available');
         }

--- a/blocks-ext.js
+++ b/blocks-ext.js
@@ -1,6 +1,6 @@
 /* global nop, DialogBoxMorph, ScriptsMorph, BlockMorph, InputSlotMorph, StringMorph, Color
    ReporterBlockMorph, CommandBlockMorph, MultiArgMorph, SnapActions, isNil,
-   ReporterSlotMorph, RingMorph, SyntaxElementMorph, contains, world*/
+   ReporterSlotMorph, RingMorph, SyntaxElementMorph, contains, world, utils*/
 // Extensions to the Snap blocks
 
 
@@ -322,7 +322,7 @@ RPCInputSlotMorph.prototype.methodSignature = function () {
     if (rpc) {
         // stores information on a specific service's rpcs
         try {
-            this.fieldsFor = JSON.parse(getUrlSyncCached('/rpc/' + rpc)).rpcs;
+            this.fieldsFor = JSON.parse(utils.getUrlSyncCached('/rpc/' + rpc)).rpcs;
         } catch (e) {
             throw new Error('Service "' + rpc + '" is not available');
         }

--- a/blocks.js
+++ b/blocks.js
@@ -7960,21 +7960,14 @@ InputSlotMorph.prototype.roleNames = function () {
 // InputSlotMorph
 InputSlotMorph.prototype.getURL = function (url) {
     try {
-        url = ensureFullUrl(url);
-        var request = new XMLHttpRequest();
-        request.open('GET', url, false);
-        request.send();
-        if (request.status === 200) {
-            return request.responseText;
-        }
-        throw new Error('unable to retrieve ' + url);
+        return getUrlSync(url);
     } catch (err) {
         return '';
     }
 };
 
 InputSlotMorph.prototype.rpcNames = function () {
-    var rpcs = JSON.parse(this.getURL('/rpc')),
+    var rpcs = JSON.parse(getUrlSyncCached('/rpc')),
         dict = {};
 
     for (var i = 0; i < rpcs.length; i++) {

--- a/blocks.js
+++ b/blocks.js
@@ -146,7 +146,7 @@ fontHeight, TableFrameMorph, SpriteMorph, Context, ListWatcherMorph,
 CellMorph, DialogBoxMorph, BlockInputFragmentMorph, PrototypeHatBlockMorph,
 Costume, IDE_Morph, BlockDialogMorph, BlockEditorMorph, localize, isNil,
 isSnapObject, copy, PushButtonMorph, SpriteIconMorph, Process, AlignmentMorph,
-CustomCommandBlockMorph*/
+CustomCommandBlockMorph, utils*/
 
 // Global stuff ////////////////////////////////////////////////////////
 
@@ -7960,14 +7960,14 @@ InputSlotMorph.prototype.roleNames = function () {
 // InputSlotMorph
 InputSlotMorph.prototype.getURL = function (url) {
     try {
-        return getUrlSync(url);
+        return utils.getUrlSync(url);
     } catch (err) {
         return '';
     }
 };
 
 InputSlotMorph.prototype.rpcNames = function () {
-    var rpcs = JSON.parse(getUrlSyncCached('/rpc')),
+    var rpcs = JSON.parse(utils.getUrlSyncCached('/rpc')),
         dict = {};
 
     for (var i = 0; i < rpcs.length; i++) {

--- a/gui.js
+++ b/gui.js
@@ -357,15 +357,8 @@ IDE_Morph.prototype.interpretUrlAnchors = function (loc) {
 
     loc = loc || location;
     function getURL(url) {
-        url = ensureFullUrl(url);
         try {
-            var request = new XMLHttpRequest();
-            request.open('GET', url, false);
-            request.send();
-            if (request.status === 200) {
-                return request.responseText;
-            }
-            throw new Error('unable to retrieve ' + url);
+            return getUrlSync(url);
         } catch (err) {
             myself.showMessage('unable to retrieve project');
             return '';

--- a/gui.js
+++ b/gui.js
@@ -70,7 +70,7 @@ fontHeight, hex_sha512, sb, CommentMorph, CommandBlockMorph,
 BlockLabelPlaceHolderMorph, Audio, SpeechBubbleMorph, ScriptFocusMorph,
 XML_Element, WatcherMorph, BlockRemovalDialogMorph, saveAs, TableMorph,
 isSnapObject, isRetinaEnabled, disableRetinaSupport, enableRetinaSupport,
-isRetinaSupported, SliderMorph, Animation*/
+isRetinaSupported, SliderMorph, Animation, utils*/
 
 // Global stuff ////////////////////////////////////////////////////////
 
@@ -358,7 +358,7 @@ IDE_Morph.prototype.interpretUrlAnchors = function (loc) {
     loc = loc || location;
     function getURL(url) {
         try {
-            return getUrlSync(url);
+            return utils.getUrlSync(url);
         } catch (err) {
             myself.showMessage('unable to retrieve project');
             return '';

--- a/index.dev.html
+++ b/index.dev.html
@@ -11,6 +11,7 @@
                 SERVER_ADDRESS = SERVER_URL.replace(/^.*\/\//, ''),
                 CLIENT_ID = '_netsblox' + new Date().getTime(); // generate a client_id w/ low collision probability
         </script>
+        <script type="text/javascript" src="utils.js"></script>
         <script type="text/javascript" src="polyfill.js"></script>
         <script type="text/javascript" src="morphic.js"></script>
         <script type="text/javascript" src="locale.js"></script>

--- a/index.dot
+++ b/index.dot
@@ -20,6 +20,7 @@
                 CLIENT_ID = '{{= it.clientId }}';
         </script>
         {{ if (it.isDevMode) { }}
+        <script type="text/javascript" src="utils.js"></script>
         <script type="text/javascript" src="polyfill.js"></script>
         <script type="text/javascript" src="morphic.js"></script>
         <script type="text/javascript" src="locale.js"></script>

--- a/main.js
+++ b/main.js
@@ -1,4 +1,4 @@
-/* globals SnapCloud, SERVER_URL, NetsBloxMorph, WorldMorph, requestPromise */
+/* globals SnapCloud, SERVER_URL, NetsBloxMorph, WorldMorph, utils */
 
 var world;
 
@@ -21,7 +21,7 @@ window.onload = function () {
                 return_user: true,
                 silent: true
             };
-            return requestPromise(request, data)
+            return utils.requestPromise(request, data)
                 .then(function(res) {
                     if (!res.responseText) throw new Error('Access denied. You are not logged in.');
                     let user = JSON.parse(res.responseText);

--- a/main.js
+++ b/main.js
@@ -1,31 +1,6 @@
-/* globals SnapCloud, SERVER_URL, NetsBloxMorph, WorldMorph*/
+/* globals SnapCloud, SERVER_URL, NetsBloxMorph, WorldMorph, requestPromise */
 
 var world;
-
-function requestPromise(request, data) {
-    // takes an xhr request
-    return new Promise((resolve, reject) => {
-        // stringifying undefined => undefined
-        if (data) {
-            request.setRequestHeader(
-                'Content-Type',
-                'application/json; charset=utf-8'
-            );
-        }
-        request.send(JSON.stringify(data));
-        request.onreadystatechange = function () {
-            if (request.readyState === 4) {
-                if (request.status >= 200 && request.status < 300) {
-                    resolve(request);
-                } else {
-                    let err = new Error(request.statusText || 'Unsuccessful Xhr response');
-                    err.request = request;
-                    reject(err);
-                }
-            }
-        };
-    });
-}
 
 
 window.onload = function () {

--- a/utils.js
+++ b/utils.js
@@ -2,7 +2,9 @@
 // loaded before main nb scripts
 /* globals ensureFullUrl */
 
-function requestPromise(request, data) {
+var utils = {};
+
+utils.requestPromise = function(request, data) {
     // takes an xhr request
     return new Promise((resolve, reject) => {
         // stringifying undefined => undefined
@@ -25,10 +27,9 @@ function requestPromise(request, data) {
             }
         };
     });
-}
+};
 
-
-function memoize(func){
+utils.memoize = function(func){
     var cache = {};
     return function(){
         var key = JSON.stringify(arguments);
@@ -41,9 +42,9 @@ function memoize(func){
             return val;
         }
     };
-}
+};
 
-function getUrlSync(url) {
+utils.getUrlSync = function(url) {
     url = ensureFullUrl(url);
     var request = new XMLHttpRequest();
     request.open('GET', url, false);
@@ -52,7 +53,6 @@ function getUrlSync(url) {
         return request.responseText;
     }
     throw new Error('unable to retrieve ' + url);
-}
+};
 
-var getUrlSyncCached = memoize(getUrlSync);
-
+utils.getUrlSyncCached = utils.memoize(utils.getUrlSync);

--- a/utils.js
+++ b/utils.js
@@ -1,0 +1,58 @@
+'use strict';
+// loaded before main nb scripts
+/* globals ensureFullUrl */
+
+function requestPromise(request, data) {
+    // takes an xhr request
+    return new Promise((resolve, reject) => {
+        // stringifying undefined => undefined
+        if (data) {
+            request.setRequestHeader(
+                'Content-Type',
+                'application/json; charset=utf-8'
+            );
+        }
+        request.send(JSON.stringify(data));
+        request.onreadystatechange = function () {
+            if (request.readyState === 4) {
+                if (request.status >= 200 && request.status < 300) {
+                    resolve(request);
+                } else {
+                    let err = new Error(request.statusText || 'Unsuccessful Xhr response');
+                    err.request = request;
+                    reject(err);
+                }
+            }
+        };
+    });
+}
+
+
+function memoize(func){
+    var cache = {};
+    return function(){
+        var key = JSON.stringify(arguments);
+        if (cache[key]){
+            return cache[key];
+        }
+        else{
+            var val = func.apply(null, arguments);
+            cache[key] = val;
+            return val;
+        }
+    };
+}
+
+function getUrlSync(url) {
+    url = ensureFullUrl(url);
+    var request = new XMLHttpRequest();
+    request.open('GET', url, false);
+    request.send();
+    if (request.status === 200) {
+        return request.responseText;
+    }
+    throw new Error('unable to retrieve ' + url);
+}
+
+var getUrlSyncCached = memoize(getUrlSync);
+


### PR DESCRIPTION
- caches RPC names and method signatures reducing the number of synchronous XHR request on the main thread
- adds a new `utils.js` file.

 - [x] the PR as is is adding a few globals maybe it's a good idea to have them all under a utils object