### PR TITLE
send message linked list fixes #792

### DIFF
--- a/threads-ext.js
+++ b/threads-ext.js
@@ -71,10 +71,11 @@ NetsProcess.prototype.doSocketMessage = function (msgInfo) {
         contents[fieldNames[i]] = fieldValues[i] || '';
     }
 
+    var dstId = targetRole instanceof List ? {contents: targetRole.asArray()} : targetRole;
     var sendMessage = function() {
         ide.sockets.sendMessage({
             type: 'message',
-            dstId: targetRole,
+            dstId: dstId,
             srcId: srcId,
             msgType: name,
             content: contents


### PR DESCRIPTION
use asArray() on Snap lists before sending the message to the server to ensure consistency