### PR TITLE
Enabled creating block variables. Fixes #802

### DIFF
--- a/actions.js
+++ b/actions.js
@@ -1589,8 +1589,8 @@ ActionManager.prototype.getBlockFromId = function(id) {
         editor;
 
     // If the id is a custom block id, it is referencing the PrototypeHatBlockMorph
-    if (this._customBlocks[id]) {
-        return this._getCustomBlockEditor(id)
+    if (this._customBlocks[blockId]) {
+        block = this._getCustomBlockEditor(blockId)
             .body.contents  // get ScriptsMorph of BlockEditorMorph
             .children.find(function(child) {
                 return child instanceof PrototypeHatBlockMorph;


### PR DESCRIPTION
Previously, I had assumed that `PrototypeHatMorph`s did not have child inputs and only had next blocks (and the input spec, of course). This PR fixes the addressing to support editing child inputs (such as the list input with the block variables) for custom blocks.