### PR TITLE
Add EmbeddedNetsBloxAPI wrapper and getProjectXML. Closes #986

### DIFF
--- a/embedded-api.js
+++ b/embedded-api.js
@@ -1,0 +1,72 @@
+(function(globals) {
+
+    class EmbeddedNetsBloxAPI {
+        constructor(element) {
+            this.element = element;
+            this._requests = {};
+
+            const receiveMessage = event => {
+                const data = event.data;
+                const {id} = data;
+                const request = this._requests[id];
+                if (request) {
+                    request.resolve(data);
+                    delete this._requests[id];
+                }
+            };
+
+            window.addEventListener('message', receiveMessage, false);
+        }
+
+        async getProjectXML() {
+            const reqData = {type: 'export-project'};
+            const data = await this.reqReply(reqData);
+            return data.xml;
+        }
+
+        async import(name, content) {
+            this.call({
+                type: 'import',
+                name: name,
+                content: content,
+            });
+        }
+
+        genUuid() {
+            return Date.now() + Math.floor(Math.random() * 1000);
+        }
+
+        reqReply(reqData) {
+            const id = this.genUuid();
+            const deferred = defer();
+            this._requests[id] = deferred;
+            reqData.id = id;
+            this.element.contentWindow.postMessage(reqData);
+
+            setTimeout(() => {
+                const deferred = this._requests[id];
+                if (deferred) {
+                    deferred.reject(new Error('Timeout Exceeded'));
+                    delete this._requests[id];
+                }
+            }, 5000);
+
+            return deferred.promise;
+        }
+
+        call(msgData) {
+            this.element.contentWindow.postMessage(msgData);
+        }
+    }
+
+    function defer() {
+        const deferred = {};
+        deferred.promise = new Promise((resolve, reject) => {
+            deferred.resolve = resolve;
+            deferred.reject = reject;
+        });
+        return deferred;
+    }
+
+    globals.EmbeddedNetsBloxAPI = EmbeddedNetsBloxAPI;
+})(this);

--- a/gui-ext.js
+++ b/gui-ext.js
@@ -528,7 +528,7 @@ IDE_Morph.prototype.initializeEmbeddedAPI = function () {
         externalVariables = {},
         receiveMessage;
 
-    receiveMessage = function(event) {
+    receiveMessage = async function(event) {
         var data = event.data;
         switch (data.type) {
         case 'import':
@@ -540,6 +540,13 @@ IDE_Morph.prototype.initializeEmbeddedAPI = function () {
         case 'delete-variable':
             delete externalVariables[data.key];
             break;
+        case 'export-project':
+        {
+            const {id} = data;
+            const xml = await self.getProjectXML();
+            window.parent.postMessage({id, xml});
+            break;
+        }
         }
     };
 

--- a/test/index.html
+++ b/test/index.html
@@ -20,6 +20,7 @@
   <script src="/test/lib/expect.min.js"></script>
   <script src="/test/lib/mocha.js"></script>
   <script src="./snap-driver.js"></script>
+  <script src="../embedded-api.js"></script>
   <script>mocha.setup('bdd')</script>
 
   <script type="text/javascript" >

--- a/utils.js
+++ b/utils.js
@@ -56,3 +56,13 @@ utils.getUrlSync = function(url) {
 };
 
 utils.getUrlSyncCached = utils.memoize(utils.getUrlSync);
+
+utils.defer = function() {
+    const deferred = {};
+    deferred.promise = new Promise((resolve, reject) => {
+        deferred.resolve = resolve;
+        deferred.reject = reject;
+    });
+
+    return deferred;
+};

--- a/websockets.js
+++ b/websockets.js
@@ -74,6 +74,14 @@ WebSocketManager.MessageHandlers = {
             this.ide.exportRoom(msg.content);
         } else if (msg.action === 'save') {
             this.ide.saveRoomLocal(msg.content);
+        } else if (msg.action === 'fetch') {
+            const deferred = this.ide.projectXMLRequests[msg.id];
+            if (deferred) {
+                deferred.resolve(msg.content);
+                delete this.ide.projectXMLRequests[msg.id];
+            } else {
+                console.error(`Project request callback already resolved: ${msg.id}`);
+            }
         }
     },
 


### PR DESCRIPTION
This PR adds a wrapper for the embedded NetsBlox API. This is hosted in the repo and can be included by including the file in a script tag in the parent application's html:
```html
<script src="URL_OF_NETSBLOX_DEPLOYMENT/embedded-api.js"></script>
```

This will define `EmbeddedNetsBloxAPI` as a global which can be initialized with:
```javascript
const api = new EmbeddedNetsBloxAPI(iframeElementWithNetsBlox);
```