### PR TITLE
Hide variable watchers from context menu. Closes #1017

### DIFF
--- a/objects.js
+++ b/objects.js
@@ -9295,6 +9295,18 @@ WatcherMorph.prototype.userMenu = function () {
                 });
             }
         }
+        menu.addItem(
+            'hide...',
+            function () {
+                const ide = myself.parentThatIsA(IDE_Morph);
+                const varName = myself.getter;
+                if (myself.isTemporary()) {
+                    myself.destroy();
+                } else {
+                    ide.stage.toggleVariableWatcher(varName);
+                }
+            }
+        );
     }
     return menu;
 };


### PR DESCRIPTION
This PR adds "hide..." as a convenience to the context menu for the variable watcher. (It wasn't obvious to me why an empty "hide variable" block should remove all temporaries. This functionality has not been modified but simply adds another approach that is more intuitive imo.)

![DeepinScreenshot_select-area_20200630091133](https://user-images.githubusercontent.com/4982789/86136383-a648fb80-bab1-11ea-8592-0ec1e3e05791.png)
