### PR TITLE
Add support for linking Snap! accounts to netsblox. Closes #1049

### DIFF
--- a/src/gui.js
+++ b/src/gui.js
@@ -1114,8 +1114,8 @@ IDE_Morph.prototype.createControlBar = function () {
     button = new ToggleButtonMorph(
         null, //colors,
         this, // the IDE is the target
-        () => {
-            var menu = this.cloudMenu(),
+        async () => {
+            var menu = await this.cloudMenu(),
                 pos = this.controlBar.cloudButton.bottomLeft();
             menu.popup(this.world(), pos);
         },
@@ -3155,6 +3155,10 @@ IDE_Morph.prototype.cloudMenu = function () {
         menu.addItem(
             'Login...',
             'initializeCloud'
+        );
+        menu.addItem(
+            'Login with Snap!...',
+            'initializeCloudWithSnap'
         );
         menu.addItem(
             'Signup...',
@@ -6336,12 +6340,50 @@ IDE_Morph.prototype.userSetDragThreshold = function () {
 
 // IDE_Morph cloud interface
 
-IDE_Morph.prototype.initializeCloud = function () {
+IDE_Morph.prototype.initializeCloudWithSnap = function () {
     var world = this.world();
     new DialogBoxMorph(
         null,
         user => this.cloud.login(
             user.username.toLowerCase(),
+            user.password,
+            user.choice,
+            () => {
+                //sessionStorage.username = username;
+                this.controlBar.cloudButton.refresh();
+                this.source = 'cloud';
+
+                const {username, strategy} = this.cloud;
+                let msg = localize('Logged in as ') + username;
+                if (strategy) {
+                    msg += ` (using ${strategy})`;
+                }
+
+                this.showMessage(msg, 2);
+            },
+            this.cloudError(),
+            'Snap!'
+        )
+    ).withKey('cloudlogin').promptCredentials(
+        'Sign in with Snap!',
+        'login',
+        null,
+        null,
+        null,
+        null,
+        'stay signed in on this computer\nuntil logging out',
+        world,
+        this.cloudIcon(),
+        this.cloudMsg
+    );
+};
+
+IDE_Morph.prototype.initializeCloud = function () {
+    var world = this.world();
+    new DialogBoxMorph(
+        null,
+        user => this.cloud.login(
+            user.username,
             user.password,
             user.choice,
             () => {

--- a/src/netsblox.js
+++ b/src/netsblox.js
@@ -87,8 +87,32 @@ NetsBloxMorph.prototype.clearProject = function () {
     //SnapUndo.reset();
 };
 
-NetsBloxMorph.prototype.cloudMenu = function () {
+NetsBloxMorph.prototype.cloudMenu = async function () {
     var menu = NetsBloxMorph.uber.cloudMenu.call(this);
+
+    const isLoggedIn = this.cloud.username;
+    if (isLoggedIn) {
+        menu.addItem(
+            'Link to Snap! account...',
+            'linkAccount'
+        );
+
+        const userData = await this.cloud.getUserData();
+        if (userData && userData.linkedAccounts.length) {
+            const submenu = new MenuMorph(this);
+            userData.linkedAccounts.forEach(account => {
+                const {username} = account;
+                submenu.addItem(
+                    username,
+                    () => this.unlinkAccount(account),
+                );
+            });
+            menu.addMenu(
+                localize('Unlink Snap! account...'),
+                submenu
+            );
+        }
+    }
 
     if (this.cloud.username && this.room.isOwner()) {
         menu.addLine();
@@ -1524,4 +1548,53 @@ NetsBloxMorph.prototype.showUpdateNotification = function () {
 
 NetsBloxMorph.prototype.showBrowserNotification = function () {
     this.simpleNotification('It seems you\'re using an unsupported browser. \n Use an up-to-date Chrome browser for the best experience.');
+};
+
+NetsBloxMorph.prototype.linkAccount = function () {
+    new DialogBoxMorph(
+        null,
+        async user => {
+            try {
+                await this.cloud.linkAccount(
+                    user.username.toLowerCase(),
+                    user.password,
+                    'Snap!'
+                );
+                this.showMessage(localize('Linked account!'), 2);
+            } catch (err) {
+                this.showMessage(
+                    localize('Unable to link account:') + ' ' + err.message,
+                    2
+                );
+            }
+        }
+    ).withKey('cloudlogin').promptCredentials(
+        'Sign in with Snap!',
+        'login',
+        null,
+        null,
+        null,
+        null,
+        'stay signed in on this computer\nuntil logging out',
+        this.world(),
+        this.cloudIcon(),
+        this.cloudMsg
+    );
+};
+
+NetsBloxMorph.prototype.unlinkAccount = async function (account) {
+    const {username} = account;
+    const confirmed = await this.confirm(
+        localize('Are you sure you would like to unlink ') + username + '?',
+        localize('Unlink Account?')
+    );
+
+    if (confirmed) {
+        try {
+            await this.cloud.unlinkAccount(account);
+            this.showMessage(localize('Unlinked ') + username, 2);
+        } catch (req) {
+            this.showMessage(localize('Unable to unlink account: ') + req.responseText, 2);
+        }
+    }
 };

--- a/src/netsblox.js
+++ b/src/netsblox.js
@@ -92,24 +92,17 @@ NetsBloxMorph.prototype.cloudMenu = async function () {
 
     const isLoggedIn = this.cloud.username;
     if (isLoggedIn) {
-        menu.addItem(
-            'Link to Snap! account...',
-            'linkAccount'
-        );
-
         const userData = await this.cloud.getUserData();
-        if (userData && userData.linkedAccounts.length) {
-            const submenu = new MenuMorph(this);
-            userData.linkedAccounts.forEach(account => {
-                const {username} = account;
-                submenu.addItem(
-                    username,
-                    () => this.unlinkAccount(account),
-                );
-            });
-            menu.addMenu(
+        const linkedAccounts = userData && userData.linkedAccounts;
+        if (linkedAccounts.length === 0) {
+            menu.addItem(
+                'Link to Snap! account...',
+                'linkAccount'
+            );
+        } else {
+            menu.addItem(
                 localize('Unlink Snap! account...'),
-                submenu
+                () => this.unlinkAccount(userData.linkedAccounts[0]),
             );
         }
     }


### PR DESCRIPTION
This PR adds support for linking Snap! accounts to NetsBlox accounts and using Snap! or authentication.

This adds a "Login with Snap!" option:
![DeepinScreenshot_select-area_20200831142202](https://user-images.githubusercontent.com/4982789/91758708-0c2b2f80-eb96-11ea-9c1c-70bffe48759a.png)

This will log the user in with the given Snap! credentials. If there is no existing linked NetsBlox account, one will be created.

After logging in, the cloud menu will provide an option for linking/unlinking a Snap account:
![DeepinScreenshot_select-area_20200831143315](https://user-images.githubusercontent.com/4982789/91759229-ebafa500-eb96-11ea-8292-6831c9bd0ad9.png)