### PR TITLE
added image of object block

### DIFF
--- a/src/objects-ext.js
+++ b/src/objects-ext.js
@@ -127,6 +127,12 @@ SpriteMorph.prototype.initBlocks = function () {
         spec: 'stage height'
     };
 
+    SpriteMorph.prototype.blocks.reportImageOfObject = {
+        type: 'reporter',
+        category: 'sensing',
+        spec: 'image of %self',
+    };
+
     SpriteMorph.prototype.blocks.reportUsername = {
         type: 'reporter',
         category: 'sensing',

--- a/src/objects.js
+++ b/src/objects.js
@@ -2545,6 +2545,7 @@ SpriteMorph.prototype.blockTemplates = function (category) {
         blocks.push('-');
         blocks.push(block('reportStageHeight'));
         blocks.push(block('reportStageWidth'));
+        blocks.push(block('reportImageOfObject'));
 
     // for debugging: ///////////////
 
@@ -8839,6 +8840,7 @@ StageMorph.prototype.blockTemplates = function (category) {
         blocks.push('-');
         blocks.push(block('reportStageHeight'));
         blocks.push(block('reportStageWidth'));
+        blocks.push(block('reportImageOfObject'));
 
     // for debugging: ///////////////
 

--- a/src/threads-ext.js
+++ b/src/threads-ext.js
@@ -462,6 +462,13 @@ Process.prototype.reportStageHeight = function () {
     return stage.dimensions.y;
 };
 
+Process.prototype.reportImageOfObject = function (object) {
+    object = this.reportObject(object);
+    if (object !== undefined) {
+        return new Costume(object.fullImage());
+    }
+};
+
 // helps executing async functions in custom js blocks
 // WARN it could be slower than non-promise based approach
 // when calling this function, return only if the return value is not undefined.


### PR DESCRIPTION
This adds a block called `image of _` which receives a Snap! object (can select from dropdown or with the pre-existing `object _` block), renders it on a canvas, and converts it to a costume. Motivation for this was for use in PhoneIoT, but there are probably some other applications. The code I used for this was based on the `save _ as costume named _` block from the newer versions of Snap!. They made that dev-only, I assume because it proliferates costumes which have to be saved along with the project. The block added in this PR, however, does not save it; so I think this would be ok in user mode (as far as I'm aware, it's no worse than an RPC that returns an image). I don't know where help info is added, but I think the usage is pretty self-explanatory given that the only input is a dropdown.