### PR TITLE
Fix project download from URL

### DIFF
--- a/src/gui.js
+++ b/src/gui.js
@@ -557,7 +557,7 @@ IDE_Morph.prototype.interpretUrlAnchors = async function (loc) {
             this.cloudError()(err.message);
         }
     } else if (loc.hash.substr(0, 4) === '#dl:') {
-        myself.showMessage('Fetching project\nfrom the cloud...');
+        let m = myself.showMessage('Fetching project\nfrom the cloud...');
 
         // make sure to lowercase the username
         dict = SnapCloud.parseDict(loc.hash.substr(4));
@@ -585,6 +585,7 @@ IDE_Morph.prototype.interpretUrlAnchors = async function (loc) {
             // Cleanup
             document.body.removeChild(link);
             URL.revokeObjectURL(url);
+            m.destroy();
         } catch (err) {
             this.cloudError()(err.message);
         }

--- a/src/gui.js
+++ b/src/gui.js
@@ -565,7 +565,26 @@ IDE_Morph.prototype.interpretUrlAnchors = async function (loc) {
 
         try {
             const projectData = await SnapCloud.getPublicProject(SnapCloud.encodeDict(dict));
-            window.open('data:text/xml,' + projectData);
+            const blob = new Blob([projectData], {type: 'text/xml'});
+            const url = URL.createObjectURL(blob);
+
+            // Create temporary link for download
+            const link = document.createElement("a");
+            link.href = url;
+            link.download = dict.ProjectName + ".xml";
+
+            document.body.appendChild(link);
+            link.dispatchEvent(
+                new MouseEvent('click', { 
+                bubbles: true, 
+                cancelable: true, 
+                view: window 
+                })
+            );
+
+            // Cleanup
+            document.body.removeChild(link);
+            URL.revokeObjectURL(url);
         } catch (err) {
             this.cloudError()(err.message);
         }


### PR DESCRIPTION
(I'm presuming this is how the feature was intended to work)

This fixes the `dl` option to download the project XML file.

Is there a desired behavior after the download (e.g. loading the project)? Right now this also fixes the "Fetching project from the cloud..." message from staying on screen after, but it's an empty project loaded in the editor.