### PR TITLE
Add support for sprite/stage specific palette contents. Close #1233

### DIFF
--- a/src/extensions.js
+++ b/src/extensions.js
@@ -56,13 +56,12 @@
             SpriteMorph.prototype.blockColor[name] = color;
         }
 
-        getBlockTemplates(categoryName) {
-            const categories = this.registry.flatMap(ext => ext.getCategories());
-            const category = categories.find(cat => cat.name === categoryName);
-            if (category) {
-                return category.blocks;
-            }
-            return [];
+        getPaletteContents(targetObject, categoryName) {
+            const paletteContents = this.registry.flatMap(ext => ext.getPalette())
+                .filter(paletteCat => paletteCat.isVisible(targetObject, categoryName))
+                .flatMap(paletteCat => paletteCat.contents);
+
+            return paletteContents;
         }
 
         initBlocks() {
@@ -95,6 +94,22 @@
         return [];
     };
 
+    Extension.prototype.getPalette = function(/*target, category*/) {
+        return [];
+    };
+
+    class PaletteCategory {
+        constructor(category, contents, targetObject) {
+            this.category = category;
+            this.contents = contents;
+            this.targetObject = targetObject;
+        }
+
+        isVisible(target, category) {
+            return this.category === category && (!this.targetObject || target instanceof this.targetObject);
+        }
+    }
+
     class CustomBlock {
         constructor(name, type, category, spec, defaults=[], impl) {
             this.name = name;
@@ -107,10 +122,9 @@
     }
 
     class Category {
-        constructor(name, color=new Color(120, 120, 120), blocks=[]) {
+        constructor(name, color=new Color(120, 120, 120)) {
             this.name = name;
             this.color = color;
-            this.blocks = blocks;
         }
     }
 
@@ -126,14 +140,16 @@
         }
     }
 
-    Extension.Palette = {
-        Block: PaletteBlock,
-        Space: {name: '-', type: 'space'},
-    };
+    Extension.PaletteCategory = PaletteCategory;
+    Extension.Palette = {};
+    Extension.Palette.Block = PaletteBlock;
+    Extension.Palette.Space = {name: '-', type: 'space'};
+    Extension.Palette.BigSpace = {name: '=', type: 'space'};
     Extension.Block = CustomBlock;
     Extension.Category = Category;
 
     globals.Extension = Extension;
     globals.ExtensionRegistry = ExtensionRegistry;
+
 })(this);
 var NetsBloxExtensions;

--- a/src/objects.js
+++ b/src/objects.js
@@ -2257,8 +2257,6 @@ SpriteMorph.prototype.blockTemplates = function (category) {
         blocks.push(block('yPosition', this.inheritsAttribute('y position')));
         blocks.push(watcherToggle('direction'));
         blocks.push(block('direction', this.inheritsAttribute('direction')));
-        blocks.push('=');
-        blocks.push(this.makeBlockButton(cat));
 
     } else if (cat === 'looks') {
 
@@ -2311,9 +2309,6 @@ SpriteMorph.prototype.blockTemplates = function (category) {
 
     /////////////////////////////////
 
-        blocks.push('=');
-        blocks.push(this.makeBlockButton(cat));
-
     } else if (cat === 'sound') {
 
         blocks.push(block('playSound'));
@@ -2362,9 +2357,6 @@ SpriteMorph.prototype.blockTemplates = function (category) {
 
     /////////////////////////////////
 
-        blocks.push('=');
-        blocks.push(this.makeBlockButton(cat));
-
     } else if (cat === 'pen') {
 
         blocks.push(block('clear'));
@@ -2389,8 +2381,6 @@ SpriteMorph.prototype.blockTemplates = function (category) {
         blocks.push(block('reportPenTrailsAsCostume'));
         blocks.push('-');
         blocks.push(block('doPasteOn'));
-        blocks.push('=');
-        blocks.push(this.makeBlockButton(cat));
 
     } else if (cat === 'network') {
         blocks.push(block('receiveSocketMessage'));
@@ -2493,8 +2483,6 @@ SpriteMorph.prototype.blockTemplates = function (category) {
         blocks.push(block('removeClone'));
         blocks.push('-');
         blocks.push(block('doPauseAll'));
-        blocks.push('=');
-        blocks.push(this.makeBlockButton(cat));
 
     } else if (cat === 'sensing') {
 
@@ -2567,9 +2555,6 @@ SpriteMorph.prototype.blockTemplates = function (category) {
 
 	/////////////////////////////////
 
-		blocks.push('=');
-        blocks.push(this.makeBlockButton(cat));
-
     } else if (cat === 'operators') {
 
         blocks.push(block('reifyScript'));
@@ -2632,9 +2617,6 @@ SpriteMorph.prototype.blockTemplates = function (category) {
         }
 
     /////////////////////////////////
-
-        blocks.push('=');
-        blocks.push(this.makeBlockButton(cat));
 
     } else if (cat === 'variables') {
 
@@ -2769,23 +2751,19 @@ SpriteMorph.prototype.blockTemplates = function (category) {
 
     /////////////////////////////////
 
-        blocks.push('=');
-
         if (StageMorph.prototype.enableCodeMapping) {
+            blocks.push('=');
             blocks.push(block('doMapCodeOrHeader'));
             blocks.push(block('doMapValueCode'));
             blocks.push(block('doMapListCode'));
             blocks.push('-');
             blocks.push(block('reportMappedCode'));
-            blocks.push('=');
         }
+ 	}
 
-        blocks.push(this.makeBlockButton());
-    } else if (cat === 'custom') {
-        blocks.push(this.makeBlockButton());
-    } else {
-        const ide = this.parentThatIsA(IDE_Morph);
-        const extBlocks = ide.extensions.getBlockTemplates(cat)
+    const ide = this.parentThatIsA(IDE_Morph);
+    if (ide) {
+        const extBlocks = ide.extensions.getPaletteContents(this, cat)
             .flatMap(item => {
                 switch (item.type) {
                 case 'block':
@@ -2801,8 +2779,11 @@ SpriteMorph.prototype.blockTemplates = function (category) {
                 return item;
             });
         blocks.push(...extBlocks);
-        blocks.push(this.makeBlockButton());
- 	}
+    }
+
+    blocks.push('=');
+    blocks.push(this.makeBlockButton(cat));
+
     return blocks;
 };
 
@@ -8594,8 +8575,6 @@ StageMorph.prototype.blockTemplates = function (category) {
         txt.fontSize = 9;
         txt.setColor(this.paletteTextColor);
         blocks.push(txt);
-        blocks.push('=');
-        blocks.push(this.makeBlockButton(cat));
 
     } else if (cat === 'looks') {
 
@@ -8634,9 +8613,6 @@ StageMorph.prototype.blockTemplates = function (category) {
         }
 
     /////////////////////////////////
-
-        blocks.push('=');
-        blocks.push(this.makeBlockButton(cat));
 
     } else if (cat === 'sound') {
 
@@ -8686,9 +8662,6 @@ StageMorph.prototype.blockTemplates = function (category) {
 
     /////////////////////////////////
 
-        blocks.push('=');
-        blocks.push(this.makeBlockButton(cat));
-
     } else if (cat === 'pen') {
 
         blocks.push(block('clear'));
@@ -8700,9 +8673,6 @@ StageMorph.prototype.blockTemplates = function (category) {
         blocks.push(block('reportPenTrailsAsCostume'));
         blocks.push('-');
         blocks.push(block('doPasteOn'));
-        blocks.push('=');
-        blocks.push(this.makeBlockButton(cat));
-
     } else if (cat === 'network') {
         blocks.push(block('receiveSocketMessage'));
         blocks.push(block('doSocketMessage'));
@@ -8800,8 +8770,6 @@ StageMorph.prototype.blockTemplates = function (category) {
         blocks.push(block('newClone'));
         blocks.push('-');
         blocks.push(block('doPauseAll'));
-        blocks.push('=');
-        blocks.push(this.makeBlockButton(cat));
 
     } else if (cat === 'sensing') {
 
@@ -8869,9 +8837,6 @@ StageMorph.prototype.blockTemplates = function (category) {
 
     /////////////////////////////////
 
-        blocks.push('=');
-        blocks.push(this.makeBlockButton(cat));
-
     } else if (cat === 'operators') {
 
         blocks.push(block('reifyScript'));
@@ -8934,9 +8899,6 @@ StageMorph.prototype.blockTemplates = function (category) {
         }
 
     //////////////////////////////////
-
-        blocks.push('=');
-        blocks.push(this.makeBlockButton(cat));
 
     } else if (cat === 'variables') {
 
@@ -9054,23 +9016,20 @@ StageMorph.prototype.blockTemplates = function (category) {
 
     /////////////////////////////////
 
-        blocks.push('=');
-
         if (StageMorph.prototype.enableCodeMapping) {
+            blocks.push('=');
             blocks.push(block('doMapCodeOrHeader'));
             blocks.push(block('doMapValueCode'));
             blocks.push(block('doMapListCode'));
             blocks.push('-');
             blocks.push(block('reportMappedCode'));
-            blocks.push('=');
         }
 
-        blocks.push(this.makeBlockButton());
-    } else if (cat === 'custom') {
-        blocks.push(this.makeBlockButton());
-    } else {
-        const ide = this.parentThatIsA(IDE_Morph);
-        const extBlocks = ide.extensions.getBlockTemplates(cat)
+    }
+
+    const ide = this.parentThatIsA(IDE_Morph);
+    if (ide) {
+        const extBlocks = ide.extensions.getPaletteContents(this, cat)
             .flatMap(item => {
                 switch (item.type) {
                 case 'block':
@@ -9086,8 +9045,11 @@ StageMorph.prototype.blockTemplates = function (category) {
                 return item;
             });
         blocks.push(...extBlocks);
-        blocks.push(this.makeBlockButton());
     }
+    blocks.push('=');
+    blocks.push(this.makeBlockButton(cat));
+
+
     return blocks;
 };
 

--- a/test/extensions.spec.js
+++ b/test/extensions.spec.js
@@ -2,7 +2,7 @@
 describe('extensions', function() {
     let TestExtension;
     before(() => {
-        const {NetsBloxExtensions,Extension,Color} = driver.globals();
+        const {NetsBloxExtensions,Extension,Color,SpriteMorph,StageMorph} = driver.globals();
 
         TestExtension = function() {};
         TestExtension.prototype = new Extension('TestExt');
@@ -15,12 +15,29 @@ describe('extensions', function() {
             new Extension.Category(
                 'TEST!',
                 new Color(10, 100, 10),
+            )
+        ];
+
+        TestExtension.prototype.getPalette = () => [
+            new Extension.PaletteCategory(
+                'TEST!',
+                [
+                    new Extension.Palette.Block('newBlock'),
+                    new Extension.Palette.Block('newBlock').withWatcherToggle(),
+                    new Extension.Palette.Block('spriteBlock'),
+                ],
+                SpriteMorph
+            ),
+            new Extension.PaletteCategory(
+                'TEST!',
                 [
                     new Extension.Palette.Block('newBlock'),
                     new Extension.Palette.Block('newBlock').withWatcherToggle()
-                ]
-            )
+                ],
+                StageMorph
+            ),
         ];
+
         TestExtension.prototype.getBlocks = () => [
             new Extension.Block(
                 'newBlock',
@@ -29,6 +46,14 @@ describe('extensions', function() {
                 'test block',
                 [],
                 () => 'This is a test.'
+            ),
+            new Extension.Block(
+                'spriteBlock',
+                'reporter',
+                'TEST!',
+                'sprite-only block',
+                [],
+                () => 'This is another test.'
             )
         ];
 
@@ -83,6 +108,21 @@ describe('extensions', function() {
             const {ToggleMorph} = driver.globals();
             const toggle = driver.palette().contents.children.find(child => child instanceof ToggleMorph);
             assert(toggle);
+        });
+
+        it('should show sprite block on sprite', function() {
+            const {name} = driver.ide().sprites.at(1);
+            driver.selectSprite(name);
+            driver.selectCategory('TEST!');
+            const block = driver.palette().contents.children.find(child => child.selector === 'spriteBlock');
+            assert(block);
+        });
+
+        it('should hide sprite block on stage', function() {
+            driver.selectStage();
+            driver.selectCategory('TEST!');
+            const block = driver.palette().contents.children.find(child => child.selector === 'spriteBlock');
+            assert(!block);
         });
     });
 });


### PR DESCRIPTION
This updates the extension API to make the palette contents explicit. This allows users to add new blocks of existing types and define palette contents for specific sprites/stages/etc.

