### PR TITLE
update readout fix

### DIFF
--- a/src/blocks.js
+++ b/src/blocks.js
@@ -5774,6 +5774,7 @@ HatBlockMorph.prototype.updateReadout = function () {
         readColor = new Color(242, 119, 68);
     if (!world) return;
     const ide = this.parentThatIsA(IDE_Morph);
+    if (!ide) return;
     const queue = ide.sockets.getMessageQueue(this);
     this.msgCount =  queue ? queue.contents.length : 0;
     var readout = this.readout();


### PR DESCRIPTION
This fixes issue [3171](https://github.com/NetsBlox/NetsBlox/issues/3171) from the NetsBlox repo. Turns out it was not only exclusively on the client side, but was also a one-line-fix. The issue was getting the ide object from a block morph while it was being dragged returns null.

This is potentially an issue for other blocks, but I think it has to be triggered by external code during a drag, meaning hat blocks should be the only suspects. Also, the problem code was only in updating the message queue display, so I'm thinking the others are all ok.