### PR TITLE
RPC help links to official docs

### DIFF
--- a/src/blocks-ext.js
+++ b/src/blocks-ext.js
@@ -45,16 +45,17 @@ BlockMorph.prototype.showHelp = async function() {
             metadata = metadata.rpcs[methodName];
             help = metadata.description;
             // add argument descriptions, if available
-            var args = metadata.args;
-            for (var i = 0; i < args.length; i++) {
-                var arg = args[i];
-                if (arg.description) {
-                    var optionalStr = arg.optional ? '[optional]' : '';
-                    help += '\n' + arg.name + ': ' + arg.description + ' ' + optionalStr;
-                }
+            for (const arg of metadata.args.filter(s => s.description)) {
+                var optionalStr = arg.optional ? '[optional]' : '';
+                help += `\n${arg.name}: ${arg.description} ${optionalStr}`;
             }
+            // add a direct link to the official docs page
+            const cat = metadata.categories && metadata.categories.length ? metadata.categories[0] : 'index';
+            help += `\n\n${SERVER_URL}/docs/services/${serviceName}/${cat}.html#${serviceName}.${methodName}`;
         } else {  // get service description
             help = metadata.description;
+            // add a direct link to the official docs page
+            help += `\n\n${SERVER_URL}/docs/services/${serviceName}/index.html`;
         }
         if (!help) help = 'Description not available';
     } else {


### PR DESCRIPTION
Closes #1247. This PR adds links at the bottom of the RPC help menu that go to the official documentation. The links already have the correct tag to jump to the right function on the page, but they seem to be ignored when clicked (so it'll just go to the right _page_ at the moment).