### PR TITLE
Typed RPC Input Slots

### DIFF
--- a/src/blocks-ext.js
+++ b/src/blocks-ext.js
@@ -271,14 +271,12 @@ StructInputSlotMorph.prototype.setContents = function(name, values) {
 StructInputSlotMorph.prototype.getFieldValue = function(fieldname, value, meta) {
     // Input slot is empty or has a string
     if (!value || typeof value === 'string') {
-        const baseTypes = getInputTypeMeta().baseTypes;
+        const typeMeta = getInputTypeMeta();
 
         // follow the base type chain to see if we can make a strongly typed slot
-        for (let type = (meta || {}).type; type; type = baseTypes[type.name]) {
+        for (let type = (meta || {}).type; type; type = (typeMeta[type.name] || {}).baseType) {
             if (type.name === 'Number') {
-                const v = new HintInputSlotMorph(value || '', fieldname, true, undefined, false);
-                v.setContents('');
-                return v;
+                return new HintInputSlotMorph(value || '', fieldname, true, undefined, false);
             }
             if (type.name === 'Enum') {
                 const choiceDict = {};

--- a/src/blocks-ext.js
+++ b/src/blocks-ext.js
@@ -3,11 +3,8 @@
    world, Services, BLACK, SERVER_URL*/
 // Extensions to the Snap blocks
 
-let CACHED_TYPE_META = undefined;
 function getInputTypeMeta() {
-    if (CACHED_TYPE_META) return CACHED_TYPE_META;
-    CACHED_TYPE_META = JSON.parse(utils.getUrlSync(`${SERVER_URL}/services/input-types`));
-    return CACHED_TYPE_META;
+    return utils.getUrlSyncCached(`${SERVER_URL}/services/input-types`, x => JSON.parse(x));
 }
 
 function sortDict(dict) {
@@ -188,7 +185,7 @@ function StructInputSlotMorph(
     this.fields = [];
     this.fieldContent = [];
     this.getFieldNames = typeof fieldValues === 'string' ? this[fieldValues] : fieldValues || nop;
-    this.getFieldMeta = fieldMeta || function(){};
+    this.getFieldMeta = fieldMeta || nop;
 
     InputSlotMorph.call(this, value, isNumeric, choiceDict, isReadOnly);
     this.isStatic = true;

--- a/src/blocks.js
+++ b/src/blocks.js
@@ -775,18 +775,22 @@ SyntaxElementMorph.prototype.setLabelColor = function (
     shadowOffset
 ) {
     this.children.forEach(morph => {
+        let textclr = textColor;
+        if (textclr.eq(WHITE)) textclr = morph.overrideWhite || WHITE;
+        else if (textclr.eq(BLACK)) textclr = morph.overrideBlack || BLACK;
+
         if (morph instanceof StringMorph && !morph.isProtectedLabel) {
             morph.shadowOffset = shadowOffset || morph.shadowOffset;
             morph.shadowColor = shadowColor || morph.shadowColor;
-            morph.setColor(textColor);
+            morph.setColor(textclr);
         } else if (morph instanceof MultiArgMorph
                 || morph instanceof ArgLabelMorph
                 || (morph instanceof SymbolMorph && !morph.isProtectedLabel)
                 || (morph instanceof InputSlotMorph
                     && morph.isReadOnly)) {
-            morph.setLabelColor(textColor, shadowColor, shadowOffset);
+            morph.setLabelColor(textclr, shadowColor, shadowOffset);
         } else if (morph.isLoop) { // C-shaped slot with loop arrow symbol
-            morph.loop().setLabelColor(textColor, shadowColor, shadowOffset);
+            morph.loop().setLabelColor(textclr, shadowColor, shadowOffset);
         }
     });
 };
@@ -1950,7 +1954,7 @@ SyntaxElementMorph.prototype.labelPart = function (spec) {
             MorphicPreferences.isFlat ?
                     ZERO : this.embossing, // shadowOffset
             this.color.darker(this.labelContrast), // shadowColor
-            WHITE, // color
+            this.overrideWhite || WHITE, // color
             this.labelFontName // fontName
         );
 
@@ -2517,13 +2521,13 @@ BlockSymbolMorph.prototype.getRenderColor = function () {
     var block = this.parentThatIsA(BlockMorph);
     if (MorphicPreferences.isFlat) {
         if (this.isFading) {
-            return this.color.mixed(block.alpha, WHITE);
+            return this.color.mixed(block.alpha, this.overrideWhite || WHITE);
         }
-        if (this.color.eq(WHITE)) {
+        if (this.color.eq(this.overrideWhite || WHITE)) {
             return this.parent.alpha > 0.5 ? this.color
                 : block.color.solid().darker(Math.max(block.alpha * 200, 0.1));
         }
-        if (this.color.eq(BLACK)) {
+        if (this.color.eq(this.overrideBlack || BLACK)) {
             return this.parent.alpha > 0.5 ? this.color
                 : block.color.solid().darker(Math.max(block.alpha * 200, 0.1));
         }
@@ -2535,11 +2539,11 @@ BlockSymbolMorph.prototype.getRenderColor = function () {
             SpriteMorph.prototype.paletteColor
         );
     }
-    if (this.color.eq(BLACK)) {
+    if (this.color.eq(this.overrideBlack || BLACK)) {
         return block.alpha > 0.5 ? this.color
             : block.color.solid().lighter(Math.max(block.alpha * 200, 0.1));
     }
-    if (this.color.eq(WHITE)) {
+    if (this.color.eq(this.overrideWhite || WHITE)) {
         return this.parent.alpha > 0.5 ? this.color
             : block.color.solid().lighter(Math.max(block.alpha * 200, 0.1));
     }
@@ -4598,7 +4602,7 @@ BlockMorph.prototype.forceNormalColoring = function () {
     var clr = this.getCategoryColor(this.category);
     this.setColor(clr);
     this.setLabelColor(
-        WHITE,
+        this.overrideWhite || WHITE,
         clr.darker(this.labelContrast),
         MorphicPreferences.isFlat ? ZERO : this.embossing
     );
@@ -4632,13 +4636,13 @@ BlockMorph.prototype.fixLabelColor = function () {
         var clr = this.getCategoryColor(this.category);
         if (this.color.eq(clr)) {
             this.setLabelColor(
-                WHITE,
+                this.overrideWhite || WHITE,
                 clr.darker(this.labelContrast),
                 MorphicPreferences.isFlat ? null : this.embossing
             );
         } else {
             this.setLabelColor(
-                BLACK,
+                this.overrideBlack || BLACK,
                 clr.lighter(this.zebraContrast)
                     .lighter(this.labelContrast * 2),
                 MorphicPreferences.isFlat ? null : this.embossing.neg()
@@ -8971,7 +8975,7 @@ InputSlotMorph.prototype.init = function (
     this.constant = null;
 
     InputSlotMorph.uber.init.call(this, null, true);
-    this.color = WHITE;
+    this.color = this.overrideWhite || WHITE;
     this.add(contents);
     this.add(arrow);
     contents.isEditable = true;
@@ -9718,7 +9722,7 @@ InputSlotMorph.prototype.setChoices = function (dict, readonly) {
         if (!readonly) {
             cnts.shadowOffset = ZERO;
             cnts.shadowColor = null;
-            cnts.setColor(BLACK);
+            cnts.setColor(this.overrideBlack || BLACK);
         }
     }
     this.fixLayout();
@@ -9773,10 +9777,10 @@ InputSlotMorph.prototype.fixLayout = function () {
     contents.isEditable = (!this.isReadOnly);
     if (this.isReadOnly) {
         contents.disableSelecting();
-        contents.color = WHITE;
+        contents.color = this.overrideWhite || WHITE;
     } else {
         contents.enableSelecting();
-        contents.color = BLACK;
+        contents.color = this.overrideBlack || BLACK;
     }
 
     if (this.choices) {
@@ -10327,9 +10331,9 @@ InputSlotStringMorph.prototype.getRenderColor = function () {
         if (this.isEditable) {
             return this.color;
         }
-        return this.parent.alpha > 0.5 ? this.color : BLACK;
+        return this.parent.alpha > 0.5 ? this.color : this.overrideBlack || BLACK;
     }
-    return this.parent.alpha > 0.25 ? this.color : WHITE;
+    return this.parent.alpha > 0.25 ? this.color : this.overrideWhite || WHITE;
 };
 
 InputSlotStringMorph.prototype.getShadowRenderColor = function () {
@@ -11240,7 +11244,7 @@ TextSlotMorph.prototype.init = function (
     this.constant = null;
 
     InputSlotMorph.uber.init.call(this, null, null, null, null, true); // sil.
-    this.color = WHITE;
+    this.color = this.overrideWhite || WHITE;
     this.add(contents);
     this.add(arrow);
     contents.isEditable = true;

--- a/src/utils.js
+++ b/src/utils.js
@@ -44,13 +44,13 @@ utils.memoize = function(func){
     };
 };
 
-utils.getUrlSync = function(url) {
+utils.getUrlSync = function(url, parser = x => x) {
     url = ensureFullUrl(url);
     var request = new XMLHttpRequest();
     request.open('GET', url, false);
     request.send();
     if (request.status === 200) {
-        return request.responseText;
+        return parser(request.responseText);
     }
     throw new Error('unable to retrieve ' + url);
 };


### PR DESCRIPTION
This PR changes RPC input slots to use argument metadata along with [base type](https://github.com/NetsBlox/NetsBlox/pull/3213) info to make the inputs "strongly-typed". Currently, this just means numeric values get round slots that only accept number characters when typing, and enum inputs become a dropdown (which is the more interesting one).

Note: this requires [the base types PR](https://github.com/NetsBlox/NetsBlox/pull/3213) in order to work.