### PR TITLE
Add support for defining custom events. Closes #1266

### DIFF
--- a/src/actions.js
+++ b/src/actions.js
@@ -3058,7 +3058,7 @@ ActionManager.prototype.afterActionApplied = function(action) {
     // a custom block)
 
     active.onSetActive();
-    ide.events.dispatchEvent('action', action);
+    ide.events.dispatchEvent(new CustomEvent('action', {detail: action}));
 };
 
 ActionManager.prototype.onMessage = function(msg) {

--- a/src/actions.js
+++ b/src/actions.js
@@ -3058,13 +3058,7 @@ ActionManager.prototype.afterActionApplied = function(action) {
     // a custom block)
 
     active.onSetActive();
-    this.listeners.forEach(pair => {
-        const [source, origin] = pair;;
-        source.postMessage({
-            type: 'action',
-            data: action
-        }, origin);
-    });
+    ide.events.dispatchEvent('action', action);
 };
 
 ActionManager.prototype.onMessage = function(msg) {

--- a/src/gui-ext.js
+++ b/src/gui-ext.js
@@ -421,9 +421,27 @@ IDE_Morph.prototype.initializeEmbeddedAPI = function () {
             event.source.postMessage({id, type, username}, event.origin);
             break;
         }
-        case 'emit-actions':
-            SnapActions.listeners.push([event.source, event.origin]);
+        case 'add-listener':
+        {
+            const {id, eventType, listenerId} = data;
+            const {source, origin} = event;
+            const callback = event => {
+                source.postMessage({
+                    type: 'event',
+                    eventType: event.type,
+                    detail: event.detail,
+                }, origin);
+            };
+            self.events.addEventListener(eventType, listenerId, callback);
+            source.postMessage({id, type: 'reply'}, origin);
             break;
+        }
+        case 'remove-listener':
+        {
+            const {id, eventType, listenerId} = data;
+            self.events.removeEventListener(eventType, listenerId);
+            event.source.postMessage({id, type: 'reply'}, event.origin);
+        }
         }
     };
 
@@ -484,6 +502,34 @@ IDE_Morph.prototype.openRoleString = async function (role, parsed=false) {
     ].join('');
     return SnapActions.openProject(projectXml);
 };
+
+// Events ///////////////////////////////////////////
+
+class Events extends EventTarget {
+    constructor() {
+        super();
+        this._listeners = {};
+    }
+
+    dispatchEvent(type, data) {
+        super.dispatchEvent(new CustomEvent(type, {detail: data}));
+    }
+
+    _registerListener(id, callback) {
+        this._listeners[id] = callback;
+    }
+
+    addEventListener(type, id, callback) {
+        this._registerListener(id, callback);
+        return super.addEventListener(type, callback);
+    }
+
+    removeEventListener(type, id) {
+        const callback = this._listeners[id];
+        delete this._listeners[id];
+        return super.removeEventListener(type, callback);
+    }
+}
 
 // LibraryDialogSources ///////////////////////////////////////////
 

--- a/src/gui-ext.js
+++ b/src/gui-ext.js
@@ -511,10 +511,6 @@ class Events extends EventTarget {
         this._listeners = {};
     }
 
-    dispatchEvent(type, data) {
-        super.dispatchEvent(new CustomEvent(type, {detail: data}));
-    }
-
     _registerListener(id, callback) {
         this._listeners[id] = callback;
     }

--- a/src/gui.js
+++ b/src/gui.js
@@ -308,6 +308,7 @@ IDE_Morph.prototype.init = function (isAutoFill) {
     this.color = this.backgroundColor;
     this.activeEditor = this;
     this.extensions = NetsBloxExtensions;
+    this.events = new Events();
 };
 
 IDE_Morph.prototype.openIn = function (world) {

--- a/test/ide.spec.js
+++ b/test/ide.spec.js
@@ -690,7 +690,7 @@ describe('ide', function() {
 
                 const api = new EmbeddedNetsBloxAPI(frame);
                 await api.addEventListener('test', deferred.resolve);
-                driver.ide().events.dispatchEvent('test', {someData: true});
+                driver.ide().events.dispatchEvent(new CustomEvent('test', {detail: {someData: true}}));
                 const event = await deferred.promise;
                 assert.equal(event.type, 'test');
                 assert(event.detail.someData);

--- a/test/ide.spec.js
+++ b/test/ide.spec.js
@@ -671,6 +671,30 @@ describe('ide', function() {
                 const action = await getFirstAction;
                 expect(action.type).toBe('addBlock');
             });
+
+            it('should be able to unsubscribe from actions', async () => {
+                const [frame] = document.getElementsByTagName('iframe');
+
+                const api = new EmbeddedNetsBloxAPI(frame);
+                const callback = () => assert(false, 'Received action after removing listener');
+                api.addActionListener(callback);
+                api.removeActionListener(callback);
+                await driver.addBlock('forward');
+                await driver.actionsSettled();
+            });
+
+            it('should be able to subscribe to arbitrary events', async () => {
+                const [frame] = document.getElementsByTagName('iframe');
+                const {utils} = driver.globals();
+                const deferred = utils.defer();
+
+                const api = new EmbeddedNetsBloxAPI(frame);
+                await api.addEventListener('test', deferred.resolve);
+                driver.ide().events.dispatchEvent('test', {someData: true});
+                const event = await deferred.promise;
+                assert.equal(event.type, 'test');
+                assert(event.detail.someData);
+            });
         });
     });
 


### PR DESCRIPTION
This adds support for adding custom events to a project and listening to them via the embedded API. Here is an example:
In a custom block:
```javascript
const process = arguments[0];  // The last argument to a JS block is always the process itself
const events = process.receiver.parentThatIsA(IDE_Morph).events;
events.dispatchEvent(new CustomBlock('myCustomEvent', {detail: {someDataICareAbout}});
```

From the embedded API (assuming the instance is named `api`):
```javascript
api.addEventListener('myCustomEvent', event => console.log(event.detail.someDataICareAbout));
```