### PR TITLE
Add onOpenRole and onNewProject handlers for extensions. Closes #1230

### DIFF
--- a/src/extensions.js
+++ b/src/extensions.js
@@ -40,6 +40,15 @@
             SpriteMorph.prototype.initBlocks();
         }
 
+        onNewProject() {
+            this.registry.forEach(ext => ext.onNewProject());
+            this.onOpenRole();
+        }
+
+        onOpenRole() {
+            this.registry.forEach(ext => ext.onOpenRole());
+        }
+
         register(Extension) {
             if (this.isReady()) {
                 this.load(Extension);
@@ -167,6 +176,10 @@
 
     Extension.prototype.getLabelParts = function() {
         return [];
+    };
+
+    Extension.prototype.onNewProject =
+    Extension.prototype.onOpenRole = function() {
     };
 
     class LabelPart {

--- a/src/gui-ext.js
+++ b/src/gui-ext.js
@@ -500,7 +500,9 @@ IDE_Morph.prototype.openRoleString = async function (role, parsed=false) {
         role.childNamed('media').toString(),
         '</snapdata>'
     ].join('');
-    return SnapActions.openProject(projectXml);
+
+    return SnapActions.openProject(projectXml)
+        .then(() => this.extensions.onOpenRole());
 };
 
 // Events ///////////////////////////////////////////

--- a/src/netsblox.js
+++ b/src/netsblox.js
@@ -141,6 +141,7 @@ NetsBloxMorph.prototype.newProject = async function (projectName) {
         };
     }
     await this.newProjectFromInfo(projectInfo, !projectName);
+    this.extensions.onNewProject();
 };
 
 NetsBloxMorph.prototype.newProjectFromInfo = async function (projectInfo, updateUrl) {

--- a/src/room.js
+++ b/src/room.js
@@ -581,10 +581,10 @@ RoomMorph.prototype.moveToRole = function(role) {
     myself.ide.showMessage('moving to ' + role.name);
     SnapCloud.getProject(
         SnapCloud.projectId,
-        function(project) {
-            myself.ide.showMessage('moved to ' + role.name + '!');
-            myself.ide.silentSetProjectName(role.name);
-            myself.ide.source = 'cloud';
+        async project => {
+            this.ide.showMessage('moved to ' + role.name + '!');
+            this.ide.silentSetProjectName(role.name);
+            this.ide.source = 'cloud';
 
             // Load the project or make the project empty
             if (project) {
@@ -596,16 +596,18 @@ RoomMorph.prototype.moveToRole = function(role) {
                 }
 
                 if (project.SourceCode) {
-                    myself.ide.droppedText(project.SourceCode);
+                    this.ide.droppedText(project.SourceCode);
                 } else {  // newly created role
-                    SnapActions.openProject();
+                    await SnapActions.openProject();
+                    this.ide.extensions.onOpenRole();
                 }
             } else {  // Empty the project FIXME
-                SnapActions.openProject();
+                await SnapActions.openProject();
+                this.ide.extensions.onOpenRole();
             }
         },
-        function (err, lbl) {
-            myself.ide.cloudError().call(null, err, lbl);
+        (err, lbl) => {
+            this.ide.cloudError().call(null, err, lbl);
         },
         role.id
     );

--- a/test/extensions.spec.js
+++ b/test/extensions.spec.js
@@ -193,4 +193,28 @@ describe('extensions', function() {
             assert(!block);
         });
     });
+
+    describe('onNewProject', function() {
+        it('should call function on new project', function(done) {
+            driver.reset();
+            TestExtension.prototype.onNewProject = () => {
+                delete TestExtension.prototype.onNewProject;
+                done();
+            };
+        });
+    });
+
+    describe('onOpenRole', function() {
+        it('should call function on switch roles', async function() {
+            const {utils} = driver.globals();
+            await driver.newRole('testRole');
+            const deferred = utils.defer();
+            TestExtension.prototype.onOpenRole = () => {
+                delete TestExtension.prototype.onOpenRole;
+                deferred.resolve();
+            };
+            await driver.moveToRole('testRole');
+            await deferred.promise;
+        });
+    });
 });


### PR DESCRIPTION
Adding `onOpenRole` to an extension will define logic that is invoked when a role is opened. `onNewProject` is invoked only when creating a new project (after which `onOpenRole` will be called).