### PR TITLE
Run extension onOpenRole in all changes of role

### DIFF
--- a/src/actions.js
+++ b/src/actions.js
@@ -2655,7 +2655,8 @@ ActionManager.prototype.onImportBlocks = function(aString, lbl) {
     this.completeAction(null, blocks);
 };
 
-ActionManager.prototype.onOpenProject = async function(str) {
+ActionManager.prototype.onOpenProject = async function (str) {
+    
     var myself = this,
         project = null,
         event = this.currentEvent,
@@ -2666,13 +2667,13 @@ ActionManager.prototype.onOpenProject = async function(str) {
 
     if (str) {
         if (str.indexOf('<project') === 0) {
-            project = this.ide().rawOpenProjectString(str);
+            project = ide.rawOpenProjectString(str);
         } else if (str.indexOf('<snapdata') === 0) {
-            project = this.ide().rawOpenCloudDataString(str);
+            project = ide.rawOpenCloudDataString(str);
         }
 
     } else {
-        this.ide().newRole();
+        ide.newRole();
     }
 
     // Load the owners
@@ -2683,7 +2684,7 @@ ActionManager.prototype.onOpenProject = async function(str) {
     this.lastSeen = event.id;  // don't reset lastSeen
     this.completeAction(null, project);
 
-    if (!this.ide().isReplayMode) {
+    if (!ide.isReplayMode) {
         // Load the replay and action manager state from project
         var len = SnapUndo.allEvents.length;
 
@@ -2699,11 +2700,13 @@ ActionManager.prototype.onOpenProject = async function(str) {
             this.lastSeen = project.collabStartIndex;
         }
 
-        var roomName = this.ide().room.name,
-            roleName = this.ide().projectName;
+        var roomName = ide.room.name,
+            roleName = ide.projectName;
 
         await SnapCloud.setClientState(roomName, roleName, this.lastSeen);
         this.requestMissingActions();
+
+        ide.extensions.onOpenRole();
     }
 };
 

--- a/src/extensions.js
+++ b/src/extensions.js
@@ -42,7 +42,6 @@
 
         onNewProject() {
             this.registry.forEach(ext => ext.onNewProject());
-            this.onOpenRole();
         }
 
         onOpenRole() {

--- a/src/gui-ext.js
+++ b/src/gui-ext.js
@@ -501,8 +501,7 @@ IDE_Morph.prototype.openRoleString = async function (role, parsed=false) {
         '</snapdata>'
     ].join('');
 
-    return SnapActions.openProject(projectXml)
-        .then(() => this.extensions.onOpenRole());
+    return SnapActions.openProject(projectXml);
 };
 
 // Events ///////////////////////////////////////////

--- a/src/room.js
+++ b/src/room.js
@@ -599,11 +599,9 @@ RoomMorph.prototype.moveToRole = function(role) {
                     this.ide.droppedText(project.SourceCode);
                 } else {  // newly created role
                     await SnapActions.openProject();
-                    this.ide.extensions.onOpenRole();
                 }
             } else {  // Empty the project FIXME
                 await SnapActions.openProject();
-                this.ide.extensions.onOpenRole();
             }
         },
         (err, lbl) => {


### PR DESCRIPTION
Close #1277 

The original code tried to run `onOpenRole` after each call to `SnapActions.openProject`, but some cases were missed. This version runs `onOpenRole` any time a new project/role is opened including the default roles of projects.
