### PR TITLE
Change isAutoTrusted check to use list of sources

### DIFF
--- a/src/gui.js
+++ b/src/gui.js
@@ -3893,7 +3893,8 @@ IDE_Morph.prototype.loadExtension = async function (url) {
 };
 
 IDE_Morph.prototype.isTrustedExtension = async function (url) {
-    const isAutoTrusted = url.startsWith('/') || url.startsWith(window.location.origin);
+    const trustedSources = [ '/', window.location.origin, 'https://extensions.netsblox.org'];
+    const isAutoTrusted = trustedSources.some(source => url.startsWith(source));
     if (isAutoTrusted) {
         return true;
     }


### PR DESCRIPTION
This moves the default trusted sources into a list where additional trusted extension sources are easier to add.

Close #1280