### PR TITLE
Hand detection blocks

### DIFF
--- a/index.dot
+++ b/index.dot
@@ -53,6 +53,11 @@
         <script type="text/javascript" src="src/message-inputs.js"></script>
         <script type="text/javascript" src="src/message-listeners.js"></script>
 
+        <!-- NetsBlox Extension Dependencies -->
+        <script src="https://cdn.jsdelivr.net/npm/@mediapipe/drawing_utils/drawing_utils.js" crossorigin="anonymous"></script>
+        <script src="https://cdn.jsdelivr.net/npm/@mediapipe/hands/hands.js" crossorigin="anonymous"></script>
+
+        <!-- NetsBlox Extensions -->
         <script type="text/javascript" src="src/widgets-ext.js"></script>
         <script type="text/javascript" src="src/objects-ext.js"></script>
         <script type="text/javascript" src="src/gui-ext.js"></script>

--- a/src/blocks.js
+++ b/src/blocks.js
@@ -1513,6 +1513,18 @@ SyntaxElementMorph.prototype.labelPart = function (spec) {
             );
             part.setContents(['hue']);
             break;
+        case '%hands':
+            part = new InputSlotMorph(
+                null,
+                false,
+                {
+                    find: ['find'],
+                    render: ['render'],
+                },
+                true
+            );
+            part.setContents(['find']);
+            break;
         case '%pen':
             part = new InputSlotMorph(
                 null,

--- a/src/objects-ext.js
+++ b/src/objects-ext.js
@@ -133,10 +133,10 @@ SpriteMorph.prototype.initBlocks = function () {
         spec: 'image of %self',
     };
 
-    SpriteMorph.prototype.blocks.reportFindHands = {
+    SpriteMorph.prototype.blocks.reportHandDetection = {
         type: 'reporter',
         category: 'sensing',
-        spec: 'find hands %s',
+        spec: '%hands hands %s',
     };
 
     SpriteMorph.prototype.blocks.reportUsername = {

--- a/src/objects-ext.js
+++ b/src/objects-ext.js
@@ -133,6 +133,12 @@ SpriteMorph.prototype.initBlocks = function () {
         spec: 'image of %self',
     };
 
+    SpriteMorph.prototype.blocks.reportFindHands = {
+        type: 'reporter',
+        category: 'sensing',
+        spec: 'find hands %s',
+    };
+
     SpriteMorph.prototype.blocks.reportUsername = {
         type: 'reporter',
         category: 'sensing',

--- a/src/objects.js
+++ b/src/objects.js
@@ -2535,7 +2535,7 @@ SpriteMorph.prototype.blockTemplates = function (category) {
         blocks.push(block('reportStageWidth'));
         blocks.push(block('reportImageOfObject'));
         blocks.push('-');
-        blocks.push(block('reportFindHands'));
+        blocks.push(block('reportHandDetection'));
 
     // for debugging: ///////////////
 
@@ -8819,7 +8819,7 @@ StageMorph.prototype.blockTemplates = function (category) {
         blocks.push(block('reportStageWidth'));
         blocks.push(block('reportImageOfObject'));
         blocks.push('-');
-        blocks.push(block('reportFindHands'));
+        blocks.push(block('reportHandDetection'));
 
     // for debugging: ///////////////
 

--- a/src/objects.js
+++ b/src/objects.js
@@ -2534,6 +2534,8 @@ SpriteMorph.prototype.blockTemplates = function (category) {
         blocks.push(block('reportStageHeight'));
         blocks.push(block('reportStageWidth'));
         blocks.push(block('reportImageOfObject'));
+        blocks.push('-');
+        blocks.push(block('reportFindHands'));
 
     // for debugging: ///////////////
 
@@ -8816,6 +8818,8 @@ StageMorph.prototype.blockTemplates = function (category) {
         blocks.push(block('reportStageHeight'));
         blocks.push(block('reportStageWidth'));
         blocks.push(block('reportImageOfObject'));
+        blocks.push('-');
+        blocks.push(block('reportFindHands'));
 
     // for debugging: ///////////////
 

--- a/src/threads-ext.js
+++ b/src/threads-ext.js
@@ -560,8 +560,11 @@ Process.prototype.reportHandDetection = function (mode, img) {
     mode = mode?.toString();
     if (!mode) throw Error(`No hand detection mode specified`);
 
+    img = img?.contents || img;
+    if (!img || typeof(img) !== 'object' || !img.width || !img.height) throw Error('Expected an image as input');
+
     if (mode === 'find') {
-        const res = this.runAsyncFn(this._findHands, { args: [img.contents], timeout: 10000 });
+        const res = this.runAsyncFn(this._findHands, { args: [img], timeout: 10000 });
         if (res !== undefined) {
             const parseLandmarks = raw => new List(raw.map(coords => new List(coords.map(p => new List([p.x, p.y, p.z])))));
             const landmarks = parseLandmarks(res.multiHandLandmarks);
@@ -571,7 +574,7 @@ Process.prototype.reportHandDetection = function (mode, img) {
         }
     }
     else if (mode === 'render') {
-        const res = this.runAsyncFn(this._renderHands, { args: [img.contents], timeout: 10000 });
+        const res = this.runAsyncFn(this._renderHands, { args: [img], timeout: 10000 });
         if (res !== undefined) {
             return new Costume(res);
         }

--- a/src/threads-ext.js
+++ b/src/threads-ext.js
@@ -480,25 +480,74 @@ Process.prototype.reportImageOfObject = function (object) {
     }
 };
 
-const hands = new Hands({ locateFile: file => `https://cdn.jsdelivr.net/npm/@mediapipe/hands/${file}` });
-hands.setOptions({
-    maxNumHands: 2,
-    modelComplexity: 1,
-    minDetectionConfidence: 0.5,
-    minTrackingConfidence: 0.5,
-});
-const handsResults = {};
-hands.onResults(results => {
-    const resolve = handsResults[results.image];
-    delete handsResults[results.image];
-    resolve(results);
-});
+class HandsHandle {
+    constructor() {
+        this.resolve = null;
+        this.expiry = 0;
 
-async function _findHands(image) {
-    return await new Promise(async resolve => {
-        handsResults[image] = resolve;
-        await hands.send({ image });
-    });
+        this.rawHandle = new Hands({
+            locateFile: file => `https://cdn.jsdelivr.net/npm/@mediapipe/hands/${file}`,
+        });
+        this.rawHandle.setOptions({
+            maxNumHands: 2,
+            modelComplexity: 1,
+            minDetectionConfidence: 0.5,
+            minTrackingConfidence: 0.5,
+        });
+        this.rawHandle.onResults(results => {
+            const resolve = this.resolve;
+            this.resolve = null;
+            if (resolve !== null) resolve(results); // make sure resolve didn't expire
+        });
+    }
+    async infer(image) {
+        if (this.resolve !== null) throw Error('HandsHandle is currently in use');
+        this.resolve = 'loading...'; // must immediately set resolve to non-null (gets real value async-ly later)
+        this.expiry = +new Date() + 10000; // if not resolved by this time, invalidate
+
+        return await new Promise(async resolve => {
+            this.resolve = resolve;
+            await this.rawHandle.send({ image });
+        });
+    }
+    isIdle() {
+        if (this.resolve === null) return true;
+        if (+new Date() > this.expiry) {
+            this.resolve = null;
+            return true;
+        }
+        return false;
+    }
+}
+
+const HANDS_HANDLES = [];
+function getHandsHandle() {
+    for (const handle of HANDS_HANDLES) {
+        if (handle.isIdle()) return handle;
+    }
+    const handle = new HandsHandle();
+    HANDS_HANDLES.push(handle);
+    return handle;
+}
+
+Process.prototype._findHands = async function (image) {
+    const handle = getHandsHandle();
+    return await handle.infer(image);
+}
+Process.prototype._renderHands = async function (image) {
+    const data = await this._findHands(image);
+    const canvas = document.createElement('canvas');
+    canvas.width = image.width;
+    canvas.height = image.height;
+    const context = canvas.getContext('2d');
+
+    context.drawImage(image, 0, 0, canvas.width, canvas.height);
+    for (const landmarks of data.multiHandLandmarks) {
+        drawConnectors(context, landmarks, HAND_CONNECTIONS, { color: '#00ff00', lineWidth: 3 });
+        drawLandmarks(context, landmarks, { color: '#ff0000', lineWidth: 1 });
+    }
+
+    return canvas;
 }
 
 function objToStructData(obj) {
@@ -507,15 +556,27 @@ function objToStructData(obj) {
     return new List(res);
 }
 
-Process.prototype.reportFindHands = function (img) {
-    const res = this.runAsyncFn(_findHands, { args: [img.contents] });
-    if (res !== undefined) {
-        const parseLandmarks = raw => new List(raw.map(coords => new List(coords.map(p => new List([p.x, p.y, p.z])))));
-        const landmarks = parseLandmarks(res.multiHandLandmarks);
-        const worldLandmarks = parseLandmarks(res.multiHandWorldLandmarks);
-        const handedness = new List(res.multiHandedness.map(e => objToStructData({ index: e.index, score: e.score, label: e.label })));
-        return objToStructData({ landmarks, worldLandmarks, handedness });
+Process.prototype.reportHandDetection = function (mode, img) {
+    mode = mode?.toString();
+    if (!mode) throw Error(`No hand detection mode specified`);
+
+    if (mode === 'find') {
+        const res = this.runAsyncFn(this._findHands, { args: [img.contents], timeout: 10000 });
+        if (res !== undefined) {
+            const parseLandmarks = raw => new List(raw.map(coords => new List(coords.map(p => new List([p.x, p.y, p.z])))));
+            const landmarks = parseLandmarks(res.multiHandLandmarks);
+            const worldLandmarks = parseLandmarks(res.multiHandWorldLandmarks);
+            const handedness = new List(res.multiHandedness.map(e => objToStructData({ index: e.index, score: e.score, label: e.label })));
+            return objToStructData({ landmarks, worldLandmarks, handedness });
+        }
     }
+    else if (mode === 'render') {
+        const res = this.runAsyncFn(this._renderHands, { args: [img.contents], timeout: 10000 });
+        if (res !== undefined) {
+            return new Costume(res);
+        }
+    }
+    else throw Error(`Unknown hand detection mode: "${mode}"`);
 };
 
 // helps executing async functions in custom js blocks


### PR DESCRIPTION
@brollb Adds a block for performing client-side hand detection via mediapipe. The block has two modes: `find`, which just does forward inference and gives back the 3d hand anchor points (possibly for multiple hands), and `render`, which gives back an image (example below). The solution is pretty fast: around 21fps on my system (looks like it's loading some vectorized wasm library under the hood).

I saw Snap! has some blocks for e.g. object tracking, but from experimentation they're not very good... I figure we can add more powerful versions like this (mediapipe has several other interesting things like object detection and face meshing) and maybe use them in some ML/HCI curriculum down the road.

![Screenshot from 2022-01-31 23-01-03](https://user-images.githubusercontent.com/37459229/151915273-41a3ab06-d85a-4e3c-a050-f0631b0e955c.png)