### PR TITLE
fix rpc defaults in foreach

### DIFF
--- a/src/threads.js
+++ b/src/threads.js
@@ -2473,31 +2473,32 @@ Process.prototype.doForEach = function (upvar, list, script) {
     // Distinguish between linked and arrayed lists.
 
     var next;
-    if (this.context.accumulator === null) {
+    let acc = this.context.accumulator;
+    if (acc === null) {
         this.assertType(list, 'list');
-        this.context.accumulator = {
+        acc = this.context.accumulator = {
             source : list,
             remaining : list.length(),
-            idx : 0
+            idx : 0,
+            params: new List(),
         };
     }
-    if (this.context.accumulator.remaining === 0) {
+    if (acc.remaining === 0) {
         return;
     }
-    this.context.accumulator.remaining -= 1;
-    if (this.context.accumulator.source.isLinked) {
-        next = this.context.accumulator.source.at(1);
-        this.context.accumulator.source =
-            this.context.accumulator.source.cdr();
+    acc.remaining -= 1;
+    if (acc.source.isLinked) {
+        next = acc.source.at(1);
+        acc.source = acc.source.cdr();
     } else { // arrayed
-        this.context.accumulator.idx += 1;
-        next = this.context.accumulator.source.at(this.context.accumulator.idx);
+        acc.idx += 1;
+        next = acc.source.at(acc.idx);
     }
     this.pushContext('doYield');
     this.pushContext();
     this.context.outerContext.variables.addVar(upvar);
     this.context.outerContext.variables.setVar(upvar, next);
-    this.evaluate(script, new List([next]), true);
+    this.evaluate(script, acc.params, true);
 };
 
 Process.prototype.doFor = function (upvar, start, end, script) {

--- a/src/threads.js
+++ b/src/threads.js
@@ -2473,32 +2473,31 @@ Process.prototype.doForEach = function (upvar, list, script) {
     // Distinguish between linked and arrayed lists.
 
     var next;
-    let acc = this.context.accumulator;
-    if (acc === null) {
+    if (this.context.accumulator === null) {
         this.assertType(list, 'list');
-        acc = this.context.accumulator = {
+        this.context.accumulator = {
             source : list,
             remaining : list.length(),
-            idx : 0,
-            params: new List(),
+            idx : 0
         };
     }
-    if (acc.remaining === 0) {
+    if (this.context.accumulator.remaining === 0) {
         return;
     }
-    acc.remaining -= 1;
-    if (acc.source.isLinked) {
-        next = acc.source.at(1);
-        acc.source = acc.source.cdr();
+    this.context.accumulator.remaining -= 1;
+    if (this.context.accumulator.source.isLinked) {
+        next = this.context.accumulator.source.at(1);
+        this.context.accumulator.source =
+            this.context.accumulator.source.cdr();
     } else { // arrayed
-        acc.idx += 1;
-        next = acc.source.at(acc.idx);
+        this.context.accumulator.idx += 1;
+        next = this.context.accumulator.source.at(this.context.accumulator.idx);
     }
     this.pushContext('doYield');
     this.pushContext();
     this.context.outerContext.variables.addVar(upvar);
     this.context.outerContext.variables.setVar(upvar, next);
-    this.evaluate(script, acc.params, true);
+    this.evaluate(script, new List([]), true);  // pass [] for args to disable auto-filling default (RPC) args
 };
 
 Process.prototype.doFor = function (upvar, start, end, script) {


### PR DESCRIPTION
Closes #1292. Turns out the issue was that the foreach loop was adding auto-insert variables like map does, where it takes the iterator item and inserts it into any empty slot. This was overriding rpc default values since they weren't empty at the time of invocation. This PR fixes this by removing that auto-fill behavior.

**Technically, this is a breaking change from Snap!**, but frankly I think it was a crazy idea for them to have that feature in the first place - it defeats the point of having an upvar and behaves differently than other Snap! primitives like the normal integer-based for loop.