### PR TITLE
Wait for stage pentrails to be loaded b4 runScripts. Fix #1303

### DIFF
--- a/src/gui.js
+++ b/src/gui.js
@@ -5328,43 +5328,44 @@ IDE_Morph.prototype.openCloudDataString = function (str) {
         .then(() => msg.destroy());
 };
 
-IDE_Morph.prototype.rawOpenCloudDataString = function (str) {
-    var model,
-        project;
+IDE_Morph.prototype.rawOpenCloudDataString = async function (model, parsed) {
+    var project;
     StageMorph.prototype.hiddenPrimitives = {};
     StageMorph.prototype.codeMappings = {};
     StageMorph.prototype.codeHeaders = {};
     StageMorph.prototype.enableCodeMapping = false;
-    StageMorph.prototype.enableInheritance = true;
+    StageMorph.prototype.enableInheritance = false;
     StageMorph.prototype.enableSublistIDs = false;
-    StageMorph.prototype.enablePenLogging = false;
     Process.prototype.enableLiveCoding = false;
+    Process.prototype.enablePenLogging = false;
     SnapActions.disableCollaboration();
     SnapUndo.reset();
     if (Process.prototype.isCatchingErrors) {
         try {
-            model = this.serializer.parse(str);
+            model = parsed ? model : this.serializer.parse(model);
             this.serializer.loadMediaModel(model.childNamed('media'));
+            const projectModel = await this.serializer.loadProjectModel(
+                model.childNamed('project'),
+                this,
+                model.attributes.remixID
+            );
             project = this.serializer.openProject(
-                this.serializer.loadProjectModel(
-                    model.childNamed('project'),
-                    this,
-                    model.attributes.remixID
-                ),
+                projectModel,
                 this
             );
         } catch (err) {
             this.showMessage('Load failed: ' + err);
         }
     } else {
-        model = this.serializer.parse(str);
+        model = parsed ? model : this.serializer.parse(model);
         this.serializer.loadMediaModel(model.childNamed('media'));
+        const projectModel = await this.serializer.loadProjectModel(
+            model.childNamed('project'),
+            this,
+            model.attributes.remixID
+        );
         project = this.serializer.openProject(
-            this.serializer.loadProjectModel(
-                model.childNamed('project'),
-                this,
-                model.attributes.remixID
-            ),
+            projectModel,
             this
         );
     }

--- a/src/netsblox.js
+++ b/src/netsblox.js
@@ -265,50 +265,6 @@ NetsBloxMorph.prototype.createControlBar = function () {
     };
 };
 
-NetsBloxMorph.prototype.rawOpenCloudDataString = function (model, parsed) {
-    var project;
-    StageMorph.prototype.hiddenPrimitives = {};
-    StageMorph.prototype.codeMappings = {};
-    StageMorph.prototype.codeHeaders = {};
-    StageMorph.prototype.enableCodeMapping = false;
-    StageMorph.prototype.enableInheritance = false;
-    StageMorph.prototype.enableSublistIDs = false;
-    Process.prototype.enableLiveCoding = false;
-    SnapActions.disableCollaboration();
-    SnapUndo.reset();
-    if (Process.prototype.isCatchingErrors) {
-        try {
-            // NetsBlox addition: start
-            model = parsed ? model : this.serializer.parse(model);
-            // NetsBlox addition: end
-            this.serializer.loadMediaModel(model.childNamed('media'));
-            project = this.serializer.openProject(
-                this.serializer.loadProjectModel(
-                    model.childNamed('project'),
-                    this
-                ),
-                this
-            );
-        } catch (err) {
-            this.showMessage('Load failed: ' + err);
-        }
-    } else {
-        // NetsBlox addition: start
-        model = parsed ? model : this.serializer.parse(model);
-        // NetsBlox addition: end
-        this.serializer.loadMediaModel(model.childNamed('media'));
-        project = this.serializer.openProject(
-            this.serializer.loadProjectModel(
-                model.childNamed('project'),
-                this
-            ),
-            this
-        );
-    }
-    this.stopFastTracking();
-    return project;
-};
-
 NetsBloxMorph.prototype.createSpriteBar = function () {
     NetsBloxMorph.uber.createSpriteBar.call(this);
 

--- a/src/store.js
+++ b/src/store.js
@@ -487,7 +487,7 @@ SnapSerializer.prototype.getPortableXML = function (object) {
     return xml;
 };
 
-SnapSerializer.prototype.loadProjectModel = function (xmlNode, ide, remixID) {
+SnapSerializer.prototype.loadProjectModelSync = function (xmlNode, ide, remixID) {
     // public - answer a new Project represented by the given XML top node
     // show a warning if the origin apps differ
 
@@ -505,6 +505,25 @@ SnapSerializer.prototype.loadProjectModel = function (xmlNode, ide, remixID) {
     }
     model = this.rawLoadProjectModel(xmlNode, remixID);
     this.objects = {};
+    return model;
+};
+
+SnapSerializer.prototype.loadProjectModel = async function (xmlNode, ide, remixID) {
+    const model = this.loadProjectModelSync(xmlNode, ide, remixID);
+    function waitForCallback(obj, name) {
+        const cb = obj[name];
+        if (!cb) return;
+
+        const deferred = utils.defer();
+        obj[name] = function() {
+            cb(...arguments);
+            deferred.resolve();
+        }
+
+        return deferred.promise;
+    }
+
+    await waitForCallback(model.pentrails, 'onload');
     return model;
 };
 


### PR DESCRIPTION
This PR:
- updates the project loading function to be async and resolve only after pentrails have been completely loaded
- unifies the project loading fns from netsblox.js, gui.js
- renames the old version of the project loading fn to have the `Sync` suffix. It's a little misleading since it just doesn't check if the project is completely loaded (ie, how it works before this PR)
