### PR TITLE
1310 CORS Issue X-Source Header

### DIFF
--- a/src/threads-ext.js
+++ b/src/threads-ext.js
@@ -494,7 +494,9 @@ Process.prototype.reportHTTPRequest = function (method, url, data, headers) {
                 header.at(2)
             );
         }
-        this.httpRequest.setRequestHeader('X-Source', 'NetsBlox'); // flag this as coming from the NetsBlox client
+        if (utils.isNetsBloxDomain(url)) {
+            this.httpRequest.setRequestHeader('X-Source', 'NetsBlox'); // flag this as coming from the NetsBlox client
+        }
 
         this.httpRequest.send(data || null);
     } else if (this.httpRequest.readyState === 4) {

--- a/src/threads.js
+++ b/src/threads.js
@@ -3372,7 +3372,10 @@ Process.prototype.reportURL = function (url) {
         }
         this.httpRequest = new XMLHttpRequest();
         this.httpRequest.open("GET", url, true);
-        this.httpRequest.setRequestHeader('X-Source', 'NetsBlox'); // flag this as coming from the NetsBlox client
+        if (utils.isNetsBloxDomain(url)) {
+            this.httpRequest.setRequestHeader('X-Source', 'NetsBlox'); // flag this as coming from the NetsBlox client
+        }
+
         // cache-control, commented out for now
         // added for Snap4Arduino but has issues with local robot servers
         // this.httpRequest.setRequestHeader('Cache-Control', 'max-age=0');

--- a/src/utils.js
+++ b/src/utils.js
@@ -71,3 +71,6 @@ utils.sleep = function(time=0) {
     return new Promise(resolve => setTimeout(resolve, time));
 };
 
+utils.isNetsBloxDomain = function (url) {
+    return !!url.match(/^(?:\w+:\/+)?[^/]*\bnetsblox\.org\b\/?/i)
+};


### PR DESCRIPTION
Closes #1310. Fixes a CORS issue with some websites that don't allow custom headers by only adding the `X-Source` header from #1297 if the request is going to the `netsblox.org` domain.