### PR TITLE
Remove Google Analytics from Privacy

### DIFF
--- a/privacy.html
+++ b/privacy.html
@@ -5,8 +5,8 @@
         <link rel="shortcut icon" href="favicon.ico">
     </head>
     <body>
-    <h1>NetsBlox Privacy Policy</h1>
 
+    <h1>NetsBlox Privacy Policy</h1>
     <p>
         Your privacy and safety online are very important to us. To protect your
         privacy, we limit what we collect and what we publish on the website.
@@ -15,21 +15,22 @@
         (COPPA), we are voluntarily following its rules about data collection
         from children under 13.
     </p>
-
     <p>
         We follow industry standards to maintain the security of our web
         server.  However, we cannot absolutely guarantee that malicious third
         parties will be unable to break into our database.  This privacy policy
         explains how our authorized staff and contractors will use your information.
-
     </p>
-    <h2>Information We Collect</h2>
-    <h3>Using our software</h3>
 
-    You can <a href="/">program in NetsBlox</a> without providing us with any
-    personally identifiable information at all. Without creating an account, you can still save projects on your own computer and not on our cloud. However, some of the collaboration capabilities require account creation to be able to invite and share projects with other users. You can also, without
-    providing any personally identifiable information, download our example projects, libraries,
-    and other public media.
+    <h2>Information We Collect</h2>
+
+    <h3>Using our software</h3>
+    <p>
+        You can <a href="/">program in NetsBlox</a> without providing us with any
+        personally identifiable information at all. Without creating an account, you can still save projects on your own computer and not on our cloud. However, some of the collaboration capabilities require account creation to be able to invite and share projects with other users. You can also, without
+        providing any personally identifiable information, download our example projects, libraries,
+        and other public media.
+    </p>
 
     <h3>Creating a NetsBlox account</h3>
     <p>
@@ -65,12 +66,13 @@
         email address.  But this partial birthdate information is never sent
         to our server; it is used only on your computer during the signup dialog.
     </p>
+
     <h3>Information in your projects</h3>
-
-    You can save projects on our server for your personal use,
-    or you can explicitly choose to share a project with the other
-    users of this site.
-
+    <p>
+        You can save projects on our server for your personal use,
+        or you can explicitly choose to share a project with the other
+        users of this site.
+    </p>
     <p>
         Projects that you choose to share are available for anyone
         to examine. We may examine shared projects for research purposes.
@@ -86,8 +88,8 @@
         we are required by law to investigate, and may revoke the shared
         status of that project.
     </p>
-    <h3>Communications that you initiate</h3>
 
+    <h3>Communications that you initiate</h3>
     <p>
         If you contact us by email, we save
         your email address and whatever other information you include in
@@ -95,8 +97,8 @@
         time if your message is a bug report.  We then delete your
         email.
     </p>
-    <h3>Server logging</h3>
 
+    <h3>Server logging</h3>
     <p>
         This site is hosted at the Vanderbilt University,
         Department of Computer Science.
@@ -106,7 +108,6 @@
         addresses from which our websites are accessed. We do not associate this data
         to individual user identities. The editor also reports some usage metrics.
     </p>
-
     <p>
         This information is used to improve the technical quality of the site,
         and may be used for investigation of deliberate attempts to deny the use
@@ -114,55 +115,30 @@
         information, except that your IP address may indicate your
         Internet service provider and your general geographic area.
     </p>
-    <h3>Google Analytics</h3>
 
+    <h2>How to remove your information</h2>
     <p>
-        Like many other web sites, we use Google Analytics to collect
-        statistical information about how our site is used.  We get only
-        general statistical information from Google Analytics, not
-        personally identifiable information.  <i>However, if you have ever
-        used other Google services, then Google knows who you are.</i>  We have
-        no control over their use of information; see
-        <a href="https://www.google.com/intl/en/policies/privacy/">Google's
-        privacy policy</a> for more information.
+        If you delete your account on our site, we will delete all the information associated with
+        that account, including your email and your saved projects.
     </p>
-        <p>
-            We recommend that you use
-            <a href="http://adblockplus.org/">AdBlock Plus</a>,
-            <a href="http://ghostery.com/">Ghostery</a>,
-            <a href="http://noscript.org/">NoScript</a>, and/or
-            <a href="http://privoxy.org/">Privoxy</a> to protect your browsing privacy.
-            The first two are really easy to install and use; the last two take a bit
-            more effort to whitelist sites you trust.
-            (You might also consider the tracking-free
-            <a href="http://duckduckgo.com/">DuckDuckGo</a> search engine.)
-            We have no connection with any of those services.
-        </p>
+    <p>
+        If you are the parent of a child with an account on this site
+        and would like us to remove the account, please
+        contact us, and include in your
+        message your child's account name, the email address associated
+        with the account, and a way to contact you offline (to prevent
+        forgeries).
+    </p>
 
-        <h2>How to remove your information</h2>
-
-        <p>
-            If you delete your account on our site, we will delete all the information associated with
-            that account, including your email and your saved projects.
-        </p>
-
-        <p>
-            If you are the parent of a child with an account on this site
-            and would like us to remove the account, please
-            contact us, and include in your
-            message your child's account name, the email address associated
-            with the account, and a way to contact you offline (to prevent
-            forgeries).
-        </p>
-        <h2>For further questions</h2>
-
+    <h2>For further questions</h2>
+    <p>
         The <a href="https://netsblox.org/">netsblox.org</a> site is maintained by
-
         <pre>
 Akos Ledeczi
 
 akos.ledeczi@vanderbilt.edu
         </pre>
+    </p>
 
     </body>
 </html>


### PR DESCRIPTION
Removes references to Google Analytics from the privacy page (`/privacy.html`). At this point, some Google Analytics code is still present, but only if an environment variable is set with a valid key; we no longer define said variable, so it is disabled.

_Also normalizes some indent and `<p>` inconsistencies in the html file._