### PR TITLE
Set default for rpcError

### DIFF
--- a/src/objects-ext.js
+++ b/src/objects-ext.js
@@ -265,6 +265,8 @@ SpriteMorph.prototype.reportRPCError = function () {
     return this.parentThatIsA(StageMorph).rpcError;
 };
 
+StageMorph.prototype.rpcError = null;
+
 StageMorph.prototype.reportRPCError = function () {
     return this.rpcError;
 };

--- a/src/objects-ext.js
+++ b/src/objects-ext.js
@@ -265,7 +265,7 @@ SpriteMorph.prototype.reportRPCError = function () {
     return this.parentThatIsA(StageMorph).rpcError;
 };
 
-StageMorph.prototype.rpcError = null;
+StageMorph.prototype.rpcError = '';
 
 StageMorph.prototype.reportRPCError = function () {
     return this.rpcError;

--- a/src/objects-ext.js
+++ b/src/objects-ext.js
@@ -265,7 +265,7 @@ SpriteMorph.prototype.reportRPCError = function () {
     return this.parentThatIsA(StageMorph).rpcError;
 };
 
-StageMorph.prototype.rpcError = '';
+StageMorph.prototype.rpcError = null;
 
 StageMorph.prototype.reportRPCError = function () {
     return this.rpcError;

--- a/src/threads-ext.js
+++ b/src/threads-ext.js
@@ -268,7 +268,7 @@ Process.prototype.callRPC = function (baseUrl, params, noCache) {
             if (this.rpcRequest.status < 200 || this.rpcRequest.status > 299) {
                 stage.rpcError = response;
             } else {
-                stage.rpcError = null;
+                stage.rpcError = '';
             }
             this.rpcRequest = null;
             return response;

--- a/src/threads-ext.js
+++ b/src/threads-ext.js
@@ -268,7 +268,7 @@ Process.prototype.callRPC = function (baseUrl, params, noCache) {
             if (this.rpcRequest.status < 200 || this.rpcRequest.status > 299) {
                 stage.rpcError = response;
             } else {
-                stage.rpcError = '';
+                stage.rpcError = null;
             }
             this.rpcRequest = null;
             return response;


### PR DESCRIPTION
Fix #1314 

Is there something better than `null` we could use for "no RPC error"? 