### PR TITLE
Remove empty check based on matching hint

### DIFF
--- a/src/blocks-ext.js
+++ b/src/blocks-ext.js
@@ -519,10 +519,6 @@ HintInputSlotMorph.prototype.setContents = function(value) {
 
 // Check if the given morph has been changed
 HintInputSlotMorph.prototype.changed = function() {
-    var txtMorph = this.contents();
-    if (txtMorph) {
-        this.empty = txtMorph.text === this.hintText;
-    }
     return InputSlotMorph.prototype.changed.call(this);
 };
 


### PR DESCRIPTION
Fix #1261 

This removes a check in `HintInputSlotMorph.prototype.changed` for the text displayed matching the hint text making the slot considered empty, instead relying on the check in `HintInputSlotMorph.prototype.setContents` for the slot actually being empty. 

For example, it is now possible to name a CloudVariables variable "name" and/or give it the value "value".