### PR TITLE
Change how rejected room/role names are handled in UI

### DIFF
--- a/src/room.js
+++ b/src/room.js
@@ -54,7 +54,7 @@ RoomMorph.prototype.init = function(ide) {
         null,
         WHITE
     );
-    this.roomName.mouseClickLeft = () => this.editRoomName();
+    this.roomName.mouseClickLeft = () => this.editRoomName(this.name);
     this.ownerLabel = new StringMorph(
         localize('Owner: myself'),
         false,
@@ -486,16 +486,18 @@ RoomMorph.prototype.mouseClickLeft = function() {
     }
 };
 
-RoomMorph.prototype.editRoomName = function () {
+RoomMorph.prototype.editRoomName = function (preset = '') {
     var myself = this;
     if (!this.isEditable()) {
         return;
     }
-    this.ide.prompt('New Room Name', function (name) {
+
+    (new DialogBoxMorph(null, function (name) {
         if (RoomMorph.isEmptyName(name)) return;  // empty name = cancel
 
         if (!RoomMorph.isValidName(name)) {
             // Error! name has a . or @
+            myself.editRoomName(name);
             new DialogBoxMorph().inform(
                 'Invalid Project Name',
                 'Could not set the project name because\n' +
@@ -505,7 +507,13 @@ RoomMorph.prototype.editRoomName = function () {
         } else {
             myself.setRoomName(name);
         }
-    }, null, 'editRoomName');
+    })).withKey('editRoomName').prompt(
+        'New Room Name',
+        preset,
+        this.world(),
+        null,
+        null
+    );
 };
 
 RoomMorph.prototype.validateRoleName = function (name, cb) {

--- a/src/room.js
+++ b/src/room.js
@@ -516,7 +516,7 @@ RoomMorph.prototype.editRoomName = function (preset = '') {
     );
 };
 
-RoomMorph.prototype.validateRoleName = function (name, cb) {
+RoomMorph.prototype.validateRoleName = function (name, onValid, onInvalid) {
     if (RoomMorph.isEmptyName(name)) return;  // empty role name = cancel
 
     if (this.getRole(name)) {
@@ -527,6 +527,7 @@ RoomMorph.prototype.validateRoleName = function (name, cb) {
             'the provided name already exists.',
             this.world()
         );
+        onInvalid();
     } else if (!RoomMorph.isValidName(name)) {
         // Error! name has a . or @
         new DialogBoxMorph().inform(
@@ -535,12 +536,13 @@ RoomMorph.prototype.validateRoleName = function (name, cb) {
             'the provided name is invalid',
             this.world()
         );
+        onInvalid();
     } else {
-        cb();
+        onValid();
     }
 };
 
-RoomMorph.prototype.createNewRole = function () {
+RoomMorph.prototype.createNewRole = function (defaultName = '') {
     // Ask for a new role name
     var myself = this;
 
@@ -552,7 +554,7 @@ RoomMorph.prototype.createNewRole = function () {
                     myself.onRoomStateUpdate(state);
                 },
                 myself.ide.cloudError()
-            );
+            ), function () { myself.createNewRole(roleName)};
         });
     }, null, 'createNewRole');
 };


### PR DESCRIPTION
This re-opens the room name changing dialog when a room name is rejected, so the user has a chance to fix it without retyping the whole thing.