### PR TITLE
Fix message type creation dialog

### DIFF
--- a/src/blocks-ext.js
+++ b/src/blocks-ext.js
@@ -526,6 +526,19 @@ HintInputSlotMorph.prototype.isEmptySlot = function() {
     return this.empty;
 };
 
+HintInputSlotMorph.prototype.updateFieldValue = function (newValue) {
+    var block = this.parentThatIsA(BlockMorph);
+
+    newValue = newValue !== undefined ? newValue : this.contents().text;
+    if (block.id) {  // not in the palette
+        this.setContents(this.lastValue);  // set to original value in case it fails
+        return SnapActions.setField(this, newValue);
+    } else {
+        // Handle use in message creation dialog
+        this.setContents(newValue);
+    }
+};
+
 var addStructReplaceSupport = function(fn) {
     return function(arg) {
         var structInput,

--- a/src/blocks-ext.js
+++ b/src/blocks-ext.js
@@ -166,6 +166,41 @@ MultiHintArgMorph.prototype.addInput = function () {
     this.fixLayout();
 };
 
+MultiHintArgMorph.prototype.mouseClickLeft = function (pos) {
+    
+    // if the <shift> key is pressed, repeat action 3 times
+    var target = this.selectForEdit(),
+        arrows = target.arrows(),
+        leftArrow = arrows.children[0],
+        rightArrow = arrows.children[1],
+        repetition = target.world().currentKey === 16 ? 3 : 1,
+        i;
+
+    if (rightArrow.bounds.containsPoint(pos)) {
+        for (i = 0; i < repetition; i += 1) {
+            if (rightArrow.isVisible) {
+                target.addInput();
+            }
+        }
+        // if (ide) {
+        //     ide.recordUnsavedChanges();
+        // }
+    } else if (
+        leftArrow.bounds.expandBy(this.fontSize / 3).containsPoint(pos)
+    ) {
+        for (i = 0; i < repetition; i += 1) {
+            if (leftArrow.isVisible) {
+                target.removeInput();
+            }
+        }
+        // if (ide) {
+        //     ide.recordUnsavedChanges();
+        // }
+    } else {
+        target.escalateEvent('mouseClickLeft', pos);
+    }
+};
+
 StructInputSlotMorph.prototype = new InputSlotMorph();
 StructInputSlotMorph.prototype.constructor = StructInputSlotMorph;
 StructInputSlotMorph.uber = InputSlotMorph.prototype;

--- a/src/messages.js
+++ b/src/messages.js
@@ -192,6 +192,9 @@ MessageDefinitionBlock.prototype.init = function() {
     this.category = 'network';
     this.setSpec('name: %hintname fields: %mhintfield');
     this.rerender();
+
+    // Fix for hint text display
+    this.inputs()[0].setContents('');
 };
 
 MessageDefinitionBlock.prototype.messageName = function() {

--- a/src/messages.js
+++ b/src/messages.js
@@ -144,7 +144,6 @@ MessageCreatorMorph.prototype.init = function(target, action) {
         this.parent.rerender();
         fixLayout.call(this);
         myself.fixLayout();
-        myself.handle.rerender();  // Should this be automatic?
         myself.rerender();
     };
 
@@ -175,13 +174,6 @@ MessageCreatorMorph.prototype.popUp = function () {
 
     if (world) {
         MessageCreatorMorph.uber.popUp.call(this, world);
-        this.handle = new HandleMorph(
-            this,
-            280,
-            220,
-            this.corner,
-            this.corner
-        );
     }
 };
 

--- a/src/messages.js
+++ b/src/messages.js
@@ -157,8 +157,10 @@ MessageCreatorMorph.prototype.init = function(target, action) {
 
         if (desc.name) {
             action(desc);
+            this.destroy();
+        } else {
+            world.inform('Message type must have a name');
         }
-        this.destroy();
     };
 
     this.addButton('ok', 'OK');
@@ -172,7 +174,7 @@ MessageCreatorMorph.prototype.popUp = function () {
     var world = this.target.world();
 
     if (world) {
-        BlockEditorMorph.uber.popUp.call(this, world);
+        MessageCreatorMorph.uber.popUp.call(this, world);
         this.handle = new HandleMorph(
             this,
             280,


### PR DESCRIPTION
Close #1326 

Includes fix for `name` field and some minor improvements. The dialog now tells you when you didn't specify a name instead of closing immediately, the (functionless?) handle on the dialog is removed, and the name field has its initial hint text display correctly.