### PR TITLE
fix loading binary sum/product

### DIFF
--- a/src/objects.js
+++ b/src/objects.js
@@ -1058,6 +1058,12 @@ SpriteMorph.prototype.initBlocks = function () {
             spec: '%rp %ringparms',
             alias: 'predicate ring lambda'
         },
+        reportSum: {
+            type: 'reporter',
+            category: 'operators',
+            spec: '%n + %n',
+            alias: '+'
+        },
         reportVariadicSum: {
             type: 'reporter',
             category: 'operators',
@@ -1069,6 +1075,12 @@ SpriteMorph.prototype.initBlocks = function () {
             category: 'operators',
             spec: '%n \u2212 %n',
             alias: '-'
+        },
+        reportProduct: {
+            type: 'reporter',
+            category: 'operators',
+            spec: '%n * %n',
+            alias: '*'
         },
         reportVariadicProduct: {
             type: 'reporter',


### PR DESCRIPTION
@brollb Fixes loading projects with old binary sum/product. Was just missing a block meta entry from the previous refactor (apparently I replaced the old entries instead of adding new ones, since I thought that was just for the blocks palette).