### PR TITLE
ext label parts hotfix

### DIFF
--- a/src/blocks.js
+++ b/src/blocks.js
@@ -1748,7 +1748,18 @@ SyntaxElementMorph.prototype.labelPart = function (spec) {
         // look up the spec
         info = this.labelParts[spec];
         if (!info) {
-            throw new Error('label part spec not found: "' + spec + '"');
+            info = NetsBloxExtensions.getLabelPart(spec);
+            if (!info) throw new Error('label part spec not found: "' + spec + '"');
+
+            const tags = [];
+            if (info.isNumeric) tags.push('numeric');
+            if (info.isReadOnly) tags.push('read-only');
+            if (info.isUnevaluated) tags.push('unevaluated');
+            info = {
+                type: 'input',
+                menu: info.choices,
+                tags: tags.join(' '),
+            };
         }
 
         // create the morph


### PR DESCRIPTION
@brollb In #1320 I merged some changes for vanilla labeled parts, but didn't think to test extensions. This just adds a little bridge between the old and new formats to get everything working again without having to change anything else.