### PR TITLE
Autograders Compat Fix

### DIFF
--- a/src/blocks.js
+++ b/src/blocks.js
@@ -1749,7 +1749,8 @@ SyntaxElementMorph.prototype.labelPart = function (spec) {
         info = this.labelParts[spec];
         if (!info) {
             info = NetsBloxExtensions.getLabelPart(spec);
-            if (!info) throw new Error('label part spec not found: "' + spec + '"');
+            // if (!info) throw new Error('label part spec not found: "' + spec + '"');
+            if (!info) return null;
 
             const tags = [];
             if (info.isNumeric) tags.push('numeric');


### PR DESCRIPTION
The old `labelPart` code didn't throw on failure, which existing autograders were depending on. This changes it back to return `null` on failure.