### PR TITLE
Extension preferences

### DIFF
--- a/src/extensions.js
+++ b/src/extensions.js
@@ -162,6 +162,10 @@
         return null;
     };
 
+    Extension.prototype.getPreferences = function() {
+        return null;
+    };
+
     Extension.prototype.getCategories = function() {
         return [];
     };

--- a/src/extensions.js
+++ b/src/extensions.js
@@ -162,7 +162,7 @@
         return null;
     };
 
-    Extension.prototype.getPreferences = function() {
+    Extension.prototype.getSettings = function() {
         return [];
     };
 
@@ -185,6 +185,29 @@
     Extension.prototype.onNewProject =
     Extension.prototype.onOpenRole = function() {
     };
+
+    class ExtensionSetting {
+        constructor(label, toggle, test, onHint = '', offHint = '', hide = false) {
+            this.label = label;
+            this.toggle = toggle, 
+            this.test = test, 
+            this.onHint = onHint, 
+            this.offHint = offHint, 
+            this.hide = hide
+        }
+    }
+
+    ExtensionSetting.createFromLocalStorage = function(label, id, defaultValue = false, onHint = '', offHint = '', hide = false){
+        return new ExtensionSetting(
+            label,
+            () => {
+                window.localStorage.setItem(id, !(window.localStorage.getItem(id) ?? defaultValue));
+            },
+            () => window.localStorage.getItem(id) ?? defaultValue,
+            onHint, offHint, hide);
+    }
+
+    Extension.ExtensionSetting = ExtensionSetting;
 
     class LabelPart {
         constructor(spec, fn) {

--- a/src/extensions.js
+++ b/src/extensions.js
@@ -163,7 +163,7 @@
     };
 
     Extension.prototype.getPreferences = function() {
-        return null;
+        return [];
     };
 
     Extension.prototype.getCategories = function() {

--- a/src/gui-ext.js
+++ b/src/gui-ext.js
@@ -514,20 +514,15 @@ IDE_Morph.prototype.extensionsMenu = function() {
                     prefs.forEach(pref => {
 
                         let test = pref.test;
-                        
-                        // Allow test to be boolean or function
-                        if(typeof(test) == 'function'){
-                            test = test();
-                        }
 
                         if (!pref.hide || world.currentKey == 16) {
                             newOptionsMenu.addItem(
                                 [
-                                    (test? on : off),
+                                    (test() ? on : off),
                                     pref.label
                                 ],
                                 pref.toggle,
-                                test ? pref.onHint : pref.offHint,
+                                test() ? pref.onHint : pref.offHint,
                                 pref.hide ? new Color(100, 0, 0) : null
                             );
                         }

--- a/src/gui-ext.js
+++ b/src/gui-ext.js
@@ -495,12 +495,12 @@ IDE_Morph.prototype.extensionsMenu = function() {
                     
     // Add preferences
     this.extensions.registry
-        .filter(ext => ext.getPreferences())
+        .filter(ext => ext.getSettings())
         .forEach(ext => {
             const name = ext.name || ext.constructor.name;
             let thisExtMenu = menu.items.find(item => item[0] == name);
 
-            let prefs = ext.getPreferences();
+            let prefs = ext.getSettings();
 
             if(thisExtMenu){
                 thisExtMenu = thisExtMenu[1];
@@ -510,7 +510,7 @@ IDE_Morph.prototype.extensionsMenu = function() {
                     let newOptionsMenu = new MenuMorph(this);
                     thisExtMenu.addMenu('Options', newOptionsMenu);
                     
-                    // Add each preference as a toggle
+                    // Add each setting as a toggle
                     prefs.forEach(pref => {
 
                         let test = pref.test;

--- a/src/gui-ext.js
+++ b/src/gui-ext.js
@@ -482,7 +482,61 @@ IDE_Morph.prototype.extensionsMenu = function() {
         return menu;
     };
 
-    return menuFromDict(dict);
+    let menu = menuFromDict(dict);
+
+    const on = new SymbolMorph(
+        'checkedBox',
+        MorphicPreferences.menuFontSize * 0.75
+    ),
+    off = new SymbolMorph(
+        'rectangle',
+        MorphicPreferences.menuFontSize * 0.75
+    );
+                    
+    // Add preferences
+    this.extensions.registry
+        .filter(ext => ext.getPreferences())
+        .forEach(ext => {
+            const name = ext.name || ext.constructor.name;
+            let thisExtMenu = menu.items.find(item => item[0] == name);
+
+            let prefs = ext.getPreferences();
+
+            if(thisExtMenu){
+                thisExtMenu = thisExtMenu[1];
+
+                // Only show menu if there is a non-hidden option available
+                if(prefs.find(pref => !pref.hide || world.currentKey == 16) !== undefined){
+                    let newOptionsMenu = new MenuMorph(this);
+                    thisExtMenu.addMenu('Options', newOptionsMenu);
+                    
+                    // Add each preference as a toggle
+                    prefs.forEach(pref => {
+
+                        let test = pref.test;
+                        
+                        // Allow test to be boolean or function
+                        if(typeof(test) == 'function'){
+                            test = test();
+                        }
+
+                        if (!pref.hide || world.currentKey == 16) {
+                            newOptionsMenu.addItem(
+                                [
+                                    (test? on : off),
+                                    pref.label
+                                ],
+                                pref.toggle,
+                                test ? pref.onHint : pref.offHint,
+                                pref.hide ? new Color(100, 0, 0) : null
+                            );
+                        }
+                    });
+                }
+            }
+        });
+
+    return menu;
 };
 
 IDE_Morph.prototype.requestProjectReload = async function (reason) {

--- a/test/extensions.spec.js
+++ b/test/extensions.spec.js
@@ -171,15 +171,16 @@ describe('extensions', function() {
             driver.selectCategory('TEST!');
             assert.equal(
                 driver.palette().contents.children.length,
-                2
+                5
             );
         });
 
         it('should show new blocks on the stage', function() {
             driver.selectStage();
             driver.selectCategory('TEST!');
-            assert(
-                driver.palette().contents.children.length > 1
+            assert.equal(
+                driver.palette().contents.children.length,
+                4
             );
         });
 
@@ -211,7 +212,7 @@ describe('extensions', function() {
             driver.selectCategory('TEST!');
             const block = driver.palette().contents.children.find(child => child.selector === 'spriteBlock');
             const [inputSlot] = block.inputs();
-            assert.equal(inputSlot.evaluate(), 'this is a second test');
+            assert(Object.keys(inputSlot.choices).includes('this is a second test'));
         });
 
         it('should hide sprite block on stage', function() {

--- a/test/extensions.spec.js
+++ b/test/extensions.spec.js
@@ -8,8 +8,15 @@ describe('extensions', function() {
         TestExtension.prototype = new Extension('TestExt');
         TestExtension.prototype.getMenu = () => {
             return {
-                'hello!': function() {},
+                'TestMenuItem': function() {},
             };
+        };
+        TestExtension.prototype.getSettings = () => {
+            return [new Extension.ExtensionSetting(
+                'Test Setting',
+                () => {},
+                () => false
+            )];
         };
         TestExtension.prototype.getCategories = () => [
             new Extension.Category(
@@ -104,6 +111,27 @@ describe('extensions', function() {
         driver.click(driver.ide().controlBar.extensionsButton);
         const menuItems = driver.dialog().children.map(c => c.labelString);
         assert(menuItems.includes('TestExt'));
+        driver.dialog().destroy();
+    });
+
+    it('should create menu item', function() {
+        driver.click(driver.ide().controlBar.extensionsButton);
+        driver.click(driver.dialog().children[1]);
+        const subMenuItems = driver.dialog().children[2].children.map(c => c.labelString);
+        assert(subMenuItems.includes('TestMenuItem'));
+        driver.dialog().destroy();
+    });
+
+    it('should create settings', function() {
+        driver.click(driver.ide().controlBar.extensionsButton);
+        driver.click(driver.dialog().children[1]);
+        const subMenuItems = driver.dialog().children[2].children.map(c => c.labelString);
+        assert(subMenuItems.includes('Options'));
+        driver.click(driver.dialog().children[2].children[2]);
+        
+        const optionMenuItems = driver.dialog().children[2].children[3].children.map(c => c.labelString);
+        assert(optionMenuItems.find(item => item && item[1] == 'Test Setting'));
+
         driver.dialog().destroy();
     });
 


### PR DESCRIPTION
Close #1340 

This allows extensions to optionally provide a list of toggle-able settings to be added to the menu.

@brollb Should this be called something different from "Options" in the menu, e.g. "Settings", "Preferences"? Where should the structure be documented?