### PR TITLE
extend trusted sources

### DIFF
--- a/src/gui.js
+++ b/src/gui.js
@@ -3868,8 +3868,9 @@ IDE_Morph.prototype.loadExtension = async function (url) {
 };
 
 IDE_Morph.prototype.isTrustedExtension = async function (url) {
-    const trustedSources = [ '/', window.location.origin, 'https://extensions.netsblox.org'];
-    const isAutoTrusted = trustedSources.some(source => url.startsWith(source));
+    const trustedLit = [ '/', window.location.origin];
+    const trustedPat = [/^https?:\/\/([a-zA-Z0-9\-]+\.)*netsblox.org/];
+    const isAutoTrusted = trustedLit.some(lit => url.startsWith(lit)) || trustedPat.some(pat => !!url.match(pat));
     if (isAutoTrusted) {
         return true;
     }


### PR DESCRIPTION
Curriculum project links (like https://curriculum.netsblox.org/9-week/dc/plot-co2-vs-temp.nb) work by redirecting to editor with an extension that loads the project xml we store. But currently this prompts for trusted sources every time. This PR extends trusted sources to every subdomain of `netsblox.org`.