### PR TITLE
add withCredentials to xhrs

### DIFF
--- a/src/gui.js
+++ b/src/gui.js
@@ -6906,6 +6906,7 @@ IDE_Morph.prototype.getURL = function (url, callback, responseType) {
         : 'response';
     try {
         request.open('GET', url, async);
+        request.withCredentials = true;
         if (async) {
             request.onreadystatechange = () => {
                 if (request.readyState === 4) {

--- a/src/morphic.js
+++ b/src/morphic.js
@@ -11769,6 +11769,7 @@ HandMorph.prototype.processDrop = function (event) {
     function readURL(url, callback) {
         var request = new XMLHttpRequest();
         request.open('GET', url);
+        request.withCredentials = true;
         request.onreadystatechange = () => {
             if (request.readyState === 4) {
                 if (request.responseText) {

--- a/src/netsblox.js
+++ b/src/netsblox.js
@@ -990,6 +990,7 @@ NetsBloxMorph.prototype.submitBugReport = function (desc, error) {
         url = this.cloud.url + '/BugReport';
 
     request.open('post', url);
+    request.withCredentials = true;
     request.setRequestHeader('Content-Type', 'application/json; charset=UTF-8');
     request.onreadystatechange = function () {
         if (request.readyState === 4 && !silent) {

--- a/src/threads-ext.js
+++ b/src/threads-ext.js
@@ -251,8 +251,9 @@ Process.prototype.callRPC = function (baseUrl, params, noCache) {
 
     if (!this.rpcRequest) {
         this.rpcRequest = new XMLHttpRequest();
-        this.rpcRequest.responseType = 'arraybuffer';
         this.rpcRequest.open('POST', url, true);
+        this.rpcRequest.withCredentials = true;
+        this.rpcRequest.responseType = 'arraybuffer';
         this.rpcRequest.setRequestHeader('Content-Type', 'application/json');
         this.rpcRequest.send(JSON.stringify(params));
     } else if (this.rpcRequest.readyState === 4) {
@@ -500,6 +501,7 @@ Process.prototype.reportHTTPRequest = function (method, url, data, headers) {
     if (!this.httpRequest) {
         this.httpRequest = new XMLHttpRequest();
         this.httpRequest.open(method, url, true);
+        this.httpRequest.withCredentials = true;
 
         this.assertType(headers, 'list');
         for (let i = 1; i <= headers.length(); i += 1) {

--- a/src/threads.js
+++ b/src/threads.js
@@ -3494,6 +3494,7 @@ Process.prototype.reportURL = function (url) {
         }
         this.httpRequest = new XMLHttpRequest();
         this.httpRequest.open("GET", url, true);
+        this.httpRequest.withCredentials = true;
         if (utils.isNetsBloxDomain(url)) {
             this.httpRequest.setRequestHeader('X-Source', 'NetsBlox'); // flag this as coming from the NetsBlox client
         }

--- a/src/utils.js
+++ b/src/utils.js
@@ -48,6 +48,7 @@ utils.getUrlSync = function(url, parser = x => x) {
     url = ensureFullUrl(url);
     var request = new XMLHttpRequest();
     request.open('GET', url, false);
+    request.withCredentials = true;
     request.send();
     if (request.status === 200) {
         return parser(request.responseText);


### PR DESCRIPTION
Adds `withCredentials = true` to all xhrs. At a minimum this is needed for `getUrlSync`, which is used for the `#open:<url>` anchor which would be used in conjunction with curriculum server xml links. Adding it everywhere potentially allows users to invoke other commands on the server, but nothing they wouldn't be authorized to do anyway (and even without this they could still do it through the console or with js blocks).