### PR TITLE
add metadata-based custom help prompts

### DIFF
--- a/src/blocks-ext.js
+++ b/src/blocks-ext.js
@@ -18,10 +18,37 @@ function sortDict(dict) {
     return sortedDict;
 }
 
+BlockMorph.prototype.showCustomHelp = function (help) {
+    if (typeof(help) === 'function') help = help(this);
+    if (typeof(help) !== 'object') help = { msg: help };
+    const { msg, keptInputs = [] } = help;
+
+    const cpy = this.fullCopy();
+    const inputs = cpy.inputs();
+    for (let i = 0; i < inputs.length; ++i) {
+        if (keptInputs.includes(i)) continue;
+        const input = inputs[i];
+
+        if (input.setContents) {
+            input.setContents('');
+        } else {
+            input.userDestroy();
+        }
+    }
+
+    new DialogBoxMorph().inform(
+        'Help',
+        msg,
+        this.world(),
+        cpy.fullImage()
+    );
+};
 
 // support for help dialogbox on service blocks
 BlockMorph.prototype._showHelp = BlockMorph.prototype.showHelp;
 BlockMorph.prototype.showHelp = async function() {
+    const blockInfo = SpriteMorph.prototype.blocks[this.selector];
+    if (blockInfo && blockInfo.help) return this.showCustomHelp(blockInfo.help);
     if (!this.isServiceBlock()) return this._showHelp();
     var myself = this,
         help,

--- a/src/objects-ext.js
+++ b/src/objects-ext.js
@@ -59,7 +59,8 @@ SpriteMorph.prototype.initBlocks = function () {
     SpriteMorph.prototype.blocks.reportRPCError = {
         type: 'reporter',
         category: 'network',
-        spec: 'error'
+        spec: 'error',
+        help: 'Get the most recent error from an RPC.\nIf the most recent RPC was successful, an empty result is returned instead.\nThis can be used after an RPC to detect failures and correct them if needed.'
     };
 
     // Network Messages
@@ -85,7 +86,8 @@ SpriteMorph.prototype.initBlocks = function () {
     SpriteMorph.prototype.blocks.receiveSocketMessage = {
         type: 'hat',
         category: 'network',
-        spec: 'when I receive %msgOutput'
+        spec: 'when I receive %msgOutput',
+        help: 'This hat block allows you to run code when you receive a NetsBlox message over the internet.\nIn the dropdown, you can set what message type you want to receive.\nTo make a new message type, use the "Make a message type" button at the bottom of the Network tab of blocks.'
     };
 
     // Role Reporters
@@ -105,32 +107,37 @@ SpriteMorph.prototype.initBlocks = function () {
     SpriteMorph.prototype.blocks.reportLatitude = {
         type: 'reporter',
         category: 'sensing',
-        spec: 'my latitude'
+        spec: 'my latitude',
+        help: 'Reports an approximation of the latitude of your physical device/computer.'
     };
 
     SpriteMorph.prototype.blocks.reportLongitude = {
         type: 'reporter',
         category: 'sensing',
-        spec: 'my longitude'
+        spec: 'my longitude',
+        help: 'Reports an approximation of the longitude of your physical device/computer.'
     };
 
     // Stage info
     SpriteMorph.prototype.blocks.reportStageWidth = {
         type: 'reporter',
         category: 'sensing',
-        spec: 'stage width'
+        spec: 'stage width',
+        help: 'Reports the full width of the stage.'
     };
 
     SpriteMorph.prototype.blocks.reportStageHeight = {
         type: 'reporter',
         category: 'sensing',
-        spec: 'stage height'
+        spec: 'stage height',
+        help: 'Reports the full height of the stage.'
     };
 
     SpriteMorph.prototype.blocks.reportImageOfObject = {
         type: 'reporter',
         category: 'sensing',
         spec: 'image of %self',
+        help: 'Gets an image of the specified object.\nIf the Stage is selected, this gets an image of the entire stage, including sprites and pen drawings.'
     };
 
     SpriteMorph.prototype.blocks.reportUsername = {


### PR DESCRIPTION
@brollb Adds an extra blocks metadata field (client-only) that can be used to generate custom help prompts. Essentially, in addition to the usual `type`, `spec`, `category`, etc. for a block, a `help` value can be defined. If present, this can be either a string (basic static help info), an object (enabling an api for retaining some subset of input slots for the displayed block image, and possibly other configuration options down the road), or a function which receives the block as input and returns one of the previous two types (enabling a way to make input-specific messages like rpcs have for selected service/rpc).

As a proof of concept, I went ahead and added some custom help prompts to some blocks we added. Later, I'll be using this in the VM's browser extension so syscalls can have customizable help info.