### PR TITLE
add missing httprt input type

### DIFF
--- a/src/blocks.js
+++ b/src/blocks.js
@@ -408,6 +408,16 @@ SyntaxElementMorph.prototype.labelParts = {
             '96 kHz' : 96000
         }
     },
+    '%httprt': {
+        type: 'input',
+        tags: 'read-only',
+        menu: {
+            'GET': ['GET'],
+            'POST': ['POST'],
+            'PUT': ['PUT'],
+            'DELETE': ['DELETE'],
+        }
+    },
     '%interaction': {
         type: 'input',
         tags: 'read-only static',


### PR DESCRIPTION
@brollb Closes #1365. Looks like `httprt` input type was lost in the last input type refactor.