### PR TITLE
Set public flag based on the project state. Fix #1371

### DIFF
--- a/src/gui.js
+++ b/src/gui.js
@@ -8076,7 +8076,12 @@ CloudProjectsSource.prototype.open = async function(metadata) {
 };
 
 CloudProjectsSource.prototype.list = async function() {
-    return await this.ide.cloud.getProjectList();
+    const projects = await this.ide.cloud.getProjectList();
+    projects.forEach(metadata => {
+      const isPublic = metadata.state === 'Public' || metadata.state === 'PendingApproval';
+      metadata.public = isPublic;
+    });
+  return projects;
 };
 
 CloudProjectsSource.prototype.getPreview = function(project) {


### PR DESCRIPTION
This uses the internal project state (private, public, pending approval) to set the `public` flag used to bold the project names for the user.
