### PR TITLE
Add IDE messaging support to extensions API. Close #1406

### DIFF
--- a/src/extensions.js
+++ b/src/extensions.js
@@ -76,6 +76,13 @@
             this.registry.forEach(ext => ext.onSetStageSize(width, height));
         }
 
+        onIDEMessage(name, data) {
+            const ext = this.registry.find(ext => ext.name === name);
+            if (ext) {
+                ext.onIDEMessage(data);
+            }
+        }
+
         register(Extension) {
             if (this.isReady()) {
                 this.load(Extension);
@@ -211,6 +218,23 @@
         return [];
     };
 
+    /**
+     * Send a message to other open NetsBlox clients (IDEs). Messages will only
+     * be accessible to NetsBlox IDEs and not programs written in NetsBlox.
+     * 
+     * Message data can be anything and will be handled only if the extension is
+     * loaded by the recipient, too.
+     */
+    Extension.prototype.sendIDEMessage = function(msgData, ...clientIds) {
+        const msg = {
+            type: 'extension',
+            name: this.name,
+            data: msgData,
+        };
+        return NetsBloxExtensions.ide.sockets.sendIDEMessage(msg, ...clientIds);
+    };
+
+    Extension.prototype.onIDEMessage =
     Extension.prototype.onRunScripts =
     Extension.prototype.onStopAllScripts =
     Extension.prototype.onPauseAll =

--- a/src/websockets.js
+++ b/src/websockets.js
@@ -47,6 +47,10 @@ class MessageHandler {
 }
 
 WebSocketManager.IDEMessageHandlers = {
+    'extension': function(msg) {
+        const {name, data} = msg;
+        NetsBloxExtensions.onIDEMessage(name, data);
+    },
     'action-rejected': function(msg) {
         if (msg.reason) {
             this.ide.showMessage(localize(msg.reason));


### PR DESCRIPTION
This adds a pair of methods to the NetsBlox extensions for sending and receiving IDE messages. Messages are addressed using client IDs (as all IDE messages) and are passed to the same extension that originated the message to avoid message naming collisions and trivial compatibility issues.

@dragazo, @gsteinLTU - How's this look? Any questions/comments/suggestions?