### PR TITLE
Add guard against non-ScriptsMorph parents. Fix #1421

### DIFF
--- a/src/blocks.js
+++ b/src/blocks.js
@@ -6125,6 +6125,10 @@ ReporterBlockMorph.prototype.init = function (isPredicate) {
 // ReporterBlockMorph drag & drop:
 
 ReporterBlockMorph.prototype.snapTarget = function (hand) {
+    if (!(this.parent instanceof ScriptsMorph)) {
+        return null;
+    }
+
     return this.parent.closestInput(this, hand);
 };
 


### PR DESCRIPTION
This adds a guard to `snapTarget` to make sure the parent is a `ScriptsMorph`. This is a backport of https://github.com/jmoenig/Snap/blob/master/src/blocks.js#L7242-L7244