### PR TITLE
Clear cached image on drag and only setField if changed. Fix #1159

### DIFF
--- a/src/actions.js
+++ b/src/actions.js
@@ -1784,8 +1784,9 @@ ActionManager.prototype.ensureNotDragging = function(block) {
         var situation = hand.grabOrigin;
 
         block = hand.children[0];  // get the top block
-        block.cachedFullImage = null;
-        block.cachedFullBounds = null;
+        hand.cachedFullImage = null;
+        hand.cachedFullBounds = null;
+
         block.changed();
         block.removeShadow();
         hand.children = [];

--- a/src/blocks-ext.js
+++ b/src/blocks-ext.js
@@ -593,7 +593,8 @@ HintInputSlotMorph.prototype.updateFieldValue = function (newValue) {
     var block = this.parentThatIsA(BlockMorph);
 
     newValue = newValue !== undefined ? newValue : this.contents().text;
-    if (block.id) {  // not in the palette
+    const changed = newValue !== this.lastValue;
+    if (block.id && changed) {  // not in the palette
         this.setContents(this.lastValue);  // set to original value in case it fails
         return SnapActions.setField(this, newValue);
     } else {

--- a/src/blocks.js
+++ b/src/blocks.js
@@ -10041,7 +10041,8 @@ InputSlotMorph.prototype.updateFieldValue = function (newValue) {
     var block = this.parentThatIsA(BlockMorph);
 
     newValue = newValue !== undefined ? newValue : this.contents().text;
-    if (block.id) {  // not in the palette
+    const changed = newValue !== this.lastValue;
+    if (block.id && changed) {  // not in the palette
         this.setContents(this.lastValue);  // set to original value in case it fails
         return SnapActions.setField(this, newValue);
     }


### PR DESCRIPTION
This was a bit involved to hunt down. Basically, this is what was happening:
- block was clicked to drag on the input slot
- the mouse down handler on the input slot started editing the input
- the `grab` function was called by the `HandMorph`.
  - a cached image of the block is used to show the dragged block by the mouse
  - This triggers `world.stopEditing` which kicks off a `setField` action (async)
- The `setField` action is received. The dragged block is dropped before the action is applied. However, the cached image is not cleared correctly so it appears to be dragged

This PR includes two updates:
- Make sure `ensureNotDragging` correctly clears the cached image so we don't have an image of the block following the cursor
- Only send `setField` actions if the value of the input slot has changed

