### PR TITLE
Remove redundant loading logic on move to role

### DIFF
--- a/src/netsblox.js
+++ b/src/netsblox.js
@@ -828,7 +828,8 @@ NetsBloxMorph.prototype.rawOpenBlocksMsgTypeString = function (aString) {
 
 NetsBloxMorph.prototype.rawLoadCloudRole = async function (project, roleData) {
     const rolePair = Object.entries(project.roles)
-        .find(([id, metadata]) => metadata.name === roleData.name)
+        .find(([_id, metadata]) => metadata.name === roleData.name)
+
     if (!rolePair) throw new Error(`Could not find role ${roleData.name} in project.`);
     const [roleId] = rolePair;
 

--- a/src/room.js
+++ b/src/room.js
@@ -627,19 +627,6 @@ RoomMorph.prototype.moveToRole = async function(role) {
     await this.ide.rawLoadCloudRole(metadata, roleData);
 
     this.ide.showMessage('moved to ' + role.name + '!');
-    this.ide.silentSetProjectName(role.name);
-    this.ide.source = 'cloud';
-
-    // Load the project or make the project empty
-    if (metadata.public === true) {
-        this.ide.updateUrlQueryString(metadata);
-    }
-
-    if (roleData.code) {
-        this.ide.droppedText(roleData.code + roleData.media);
-    } else {  // newly created role
-        await SnapActions.openProject();
-    }
 };
 
 RoomMorph.prototype.deleteRole = async function(role) {


### PR DESCRIPTION
This was causing media not to be loaded since the dropped text was actually
the incorrect format - they needed to be wrapped in <snapdata></snapdata>.
This is handled correctly in the initial load in `rawLoadCloudRole`
