### PR TITLE
Fix scroll position after click in open/save dialogs

### DIFF
--- a/src/gui.js
+++ b/src/gui.js
@@ -7407,7 +7407,6 @@ SaveOpenDialogMorph.prototype.setSource = async function (newSource) {
             this.shareButton.hide();
         }
         this.buttons.fixLayout();
-        this.fixLayout();
         this.edit();
     };
     this.body.add(this.listField);


### PR DESCRIPTION
Removing this one line fixes the issue of the scrolling menu in the open/save dialogs moving when you select something lower in the list (which made double-clicking open something else than you intended). I couldn't find any side-effects of it, the item is still highlighted and double-clicking or clicking open worked as expected.