### PR TITLE
Revert "Fix scroll position after click in open/save dialogs"

### DIFF
--- a/src/gui.js
+++ b/src/gui.js
@@ -7428,6 +7428,7 @@ SaveOpenDialogMorph.prototype.setSource = async function (newSource) {
             this.shareButton.hide();
         }
         this.buttons.fixLayout();
+        this.fixLayout();
         this.edit();
     };
     this.body.add(this.listField);


### PR DESCRIPTION
@gsteinLTU - I found out why `fixLayout` was needed:
![FixLayoutError](https://github.com/NetsBlox/Snap--Build-Your-Own-Blocks/assets/4982789/db83a750-90aa-43a2-9a15-6648d4d0eb2d)


I am reverting it for now until we can dig further into it.