### PR TITLE
Prevent browser file open dialog from being triggered on ctrl/command+O

### DIFF
--- a/src/morphic.js
+++ b/src/morphic.js
@@ -12142,9 +12142,9 @@ WorldMorph.prototype.initKeyboardHandler = function () {
                 }
                 event.preventDefault();
             }
-            // suppress cmd-d/f/i/p/s override
+            // suppress cmd-d/f/i/o/p/s override
             if ((event.ctrlKey || event.metaKey) &&
-                    'dfips'.includes(event.key)) {
+                    'dfiops'.includes(event.key)) {
                 event.preventDefault();
             }
         },


### PR DESCRIPTION
Tested, browser open dialog no longer opens.