### PR TITLE
Focus morphic keyboard handler instead of canvas

### DIFF
--- a/src/gui-ext.js
+++ b/src/gui-ext.js
@@ -152,7 +152,7 @@ class UrlParams {
         // only force my world to get focus if I'm not in embed mode
         // to prevent the iFrame from involuntarily scrolling into view
         if (!ide.isEmbedMode) {
-            ide.world().worldCanvas.focus();
+            ide.world().keyboardHandler.focus();
         }
     }
 }


### PR DESCRIPTION
Close #1513 

May need a bit of testing in case there's a case where this isn't preferred. It seems to work fine in appMode, embedMode, etc. 