### PR TITLE
add voice search

### DIFF
--- a/src/objects.js
+++ b/src/objects.js
@@ -3455,7 +3455,7 @@ SpriteMorph.prototype.searchBlocks = function (
     searchPane.color = this.paletteColor;
     searchPane.contents.color = this.paletteColor;
     searchPane.addContents(searchBar);
-    searchBar.setWidth(ide.logo.width() - 30);
+    searchBar.setWidth(ide.logo.width() - 40);
     searchBar.contrast = 90;
     searchBar.setPosition(
         searchPane.contents.topLeft().add(new Point(10, 10))


### PR DESCRIPTION
Adds an experimental voice search button to the search-mode blocks palette on browsers that support it (chrome does, others are spotty, but NetsBlox itself is spotty on others anyway).

It works fairly well, but down the road we'll probably want special rules to fix things like "plus" instead of "+". But that's a problem we could address at the search level, rather than the voice recognition level (i.e., maybe we make searching in general way fuzzier so that "+", "add", "plus", and "sum" all match the add block, etc.).