### PR TITLE
default extensions

### DIFF
--- a/src/extensions.js
+++ b/src/extensions.js
@@ -19,22 +19,23 @@
         }
 
         load(Extension) {
-            // First, check if the extension is supported
             const supported = Extension.prototype.isSupported();
             if (supported !== true) {
-                if(typeof supported === 'string'){
+                if (typeof supported === 'string'){
                     this.ide.showMessage(`Unable to load extension: ${supported}`);
                 } else {
                     this.ide.showMessage(`Unable to load extension.`);
                 }
-                
+                return;
+            }
+
+            // check if already loaded before instantiating to avoid multiple instances with possible background tasks
+            if (this.registry.find(ext => ext.constructor.name === Extension.name)) {
+                console.log(`skipping extension ${Extension.name} (already loaded)`);
                 return;
             }
 
             const extension = new Extension(this.ide);  // TODO: Replace the IDE with an official API?
-            if (this.isLoaded(extension.name)) {
-                return;
-            }
 
             try {
                 this.validate(extension);
@@ -139,10 +140,6 @@
                     }
                 });
             });
-        }
-
-        isLoaded(name) {
-            return this.registry.find(ext => ext.name === name);
         }
 
         getLabelPart(spec) {

--- a/src/gui-ext.js
+++ b/src/gui-ext.js
@@ -103,19 +103,21 @@ class UrlParams {
     async apply(_ide) {}
 
     async applyInitialFlags(ide) {
-        const extensions = this.params.get('extensions');
-        if (extensions) {
-            try {
-                const extensionUrls = JSON.parse(decodeURIComponent(extensions));
-                await Promise.all(extensionUrls.map(url => ide.loadExtension(url)));
-            } catch (err) {
-                ide.inform(
-                    'Unable to load extensions',
-                    'The following error occurred while trying to load extensions:\n\n' +
-                    err.message + '\n\n' +
-                    'Perhaps the URL is malformed?'
-                );
-            }
+        const defaultExtensions = this.getParameterFlag('noDefaultExtensions') ? [] : [
+            'https://extensions.netsblox.org/extensions/BeatBlox/index.js',
+        ];
+
+        try {
+            const explicitExtensions = JSON.parse(decodeURIComponent(this.params.get('extensions') || '[]'));
+            const allExtensions = [...explicitExtensions, ...defaultExtensions]; // explicit must come before default for proper overriding
+            await Promise.all(allExtensions.map(url => ide.loadExtension(url)));
+        } catch (err) {
+            ide.inform(
+                'Unable to load extensions',
+                'The following error occurred while trying to load extensions:\n\n' +
+                err.message + '\n\n' +
+                'Perhaps the URL is malformed?'
+            );
         }
     }
 

--- a/src/gui.js
+++ b/src/gui.js
@@ -3871,7 +3871,17 @@ IDE_Morph.prototype.settingsMenu = function () {
     return menu;
 };
 
+const LOADED_EXTENSIONS = {};
 IDE_Morph.prototype.loadExtension = async function (url) {
+    const metaName = (url.match(/\/([^/]+)\/index.js/) || [])[1] || (url.match(/\/([^/]+).js/) || [])[1] || '';
+    if (metaName.length > 0) {
+        if (LOADED_EXTENSIONS[metaName] !== undefined) {
+            console.log(`skipping extension ${url} (already loaded from ${LOADED_EXTENSIONS[metaName]})`);
+            return;
+        }
+        LOADED_EXTENSIONS[metaName] = url;
+    }
+
     if (await this.isTrustedExtension(url)) {
         const node = document.createElement('script');
         node.setAttribute('src', url);


### PR DESCRIPTION
Adds a mechanism for load-by-default extensions. Extensions in the url will override default extensions, with the deduplicating logic being the file name from the extension url (either `<name>/index.js` or `<name>.js`). There's also now a `noDefaultExtensions` url flag to opt out for testing.

BeatBlox is now marked as a default extension.