### PR TITLE
extension buttons

### DIFF
--- a/src/extensions.js
+++ b/src/extensions.js
@@ -378,9 +378,18 @@
         }
     }
 
+    class PaletteButton {
+        constructor(label, action) {
+            this.label = label;
+            this.action = action;
+            this.type = 'button';
+        }
+    }
+
     Extension.PaletteCategory = PaletteCategory;
     Extension.Palette = {};
     Extension.Palette.Block = PaletteBlock;
+    Extension.Palette.Button = PaletteButton;
     Extension.Palette.Space = {name: '-', type: 'space'};
     Extension.Palette.BigSpace = {name: '=', type: 'space'};
     Extension.Block = CustomBlock;

--- a/src/objects.js
+++ b/src/objects.js
@@ -107,6 +107,18 @@ function isSnapObject(thing) {
     return thing instanceof SpriteMorph || (thing instanceof StageMorph);
 }
 
+function buildMenu(entries) {
+    const res = new MenuMorph();
+    for (const entry in entries) {
+        if (typeof(entries[entry]) === 'object') {
+            res.addMenu(entry, buildMenu(entries[entry]));
+        } else {
+            res.addItem(entry, entries[entry]);
+        }
+    }
+    return res;
+}
+
 // SpriteMorph /////////////////////////////////////////////////////////
 
 // I am a scriptable object
@@ -2909,6 +2921,15 @@ SpriteMorph.prototype.blockTemplates = function (category) {
                 switch (item.type) {
                 case 'block':
                     return block(item.name);
+                case 'button':
+                    return new PushButtonMorph(
+                        null,
+                        async function() {
+                            const res = await item.action();
+                            if (res) buildMenu(res).popUpAtHand(myself.world());
+                        },
+                        item.label,
+                    );
                 case 'watcher':
                     return [
                         watcherToggle(item.name),
@@ -9352,6 +9373,15 @@ StageMorph.prototype.blockTemplates = function (category) {
                 switch (item.type) {
                 case 'block':
                     return block(item.name);
+                case 'button':
+                    return new PushButtonMorph(
+                        null,
+                        async function() {
+                            const res = await item.action();
+                            if (res) buildMenu(res).popUpAtHand(myself.world());
+                        },
+                        item.label,
+                    );
                 case 'watcher':
                     return [
                         watcherToggle(item.name),


### PR DESCRIPTION
Extensions can now add buttons to the palette. They are defined by an async function. If they return a value, it must be of form `{ label: action,... }`, which is displayed as a dropdown menu on the button (similar to the var/msg deletion buttons). This also allows sub-menus by giving another menu object in place of an action.