### PR TITLE
separate blocks from different extensions

### DIFF
--- a/src/extensions.js
+++ b/src/extensions.js
@@ -160,11 +160,11 @@
         }
 
         getPaletteContents(targetObject, categoryName) {
-            const paletteContents = this.registry.flatMap(ext => ext.getPalette())
-                .filter(paletteCat => paletteCat.isVisible(targetObject, categoryName))
-                .flatMap(paletteCat => paletteCat.contents);
-
-            return paletteContents;
+            return this.registry.flatMap(ext => {
+                const blocks = ext.getPalette().filter(x => x.isVisible(targetObject, categoryName)).flatMap(x => x.contents);
+                if (blocks.length > 0) blocks.unshift('=');
+                return blocks;
+            });
         }
 
         findWatcherReceivers(palettes, spec) {

--- a/src/objects.js
+++ b/src/objects.js
@@ -3016,7 +3016,7 @@ SpriteMorph.prototype.freshPalette = function (category) {
         y = 5,
         ry = 0,
         blocks,
-        hideNextSpace = false,
+        hideNextSpace = true,
         stage = this.parentThatIsA(StageMorph),
         shade = new Color(140, 140, 140),
         searchButton,
@@ -9396,7 +9396,6 @@ StageMorph.prototype.blockTemplates = function (category) {
     }
     blocks.push('=');
     blocks.push(this.makeBlockButton(cat));
-
 
     return blocks;
 };


### PR DESCRIPTION
Adds a large space `'='` to the start of each extension's block list in each category. Also fixes Snap!'s palette generator to skip leading spacers (needed for new categories like music that are exclusively populated by extensions).